### PR TITLE
Test on both Python2 and 3 to ensure expected support.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,11 +17,21 @@ jobs:
           python: "3.7"
 
         - stage: upload_coverage
+          python: "2.7"
+          script: make upload-coverage
+
+        - stage: upload_coverage
           python: "3.6"
           script: make upload-coverage
 
         - stage: integration_test
           if: branch = master
+          python: "2.7"
+          script: make test-remote
+
+        - stage: integration_test
+          if: branch = master
+          python: "3.6"
           script: make test-remote
 
 before_script:

--- a/tests/integration/test_cursor.py
+++ b/tests/integration/test_cursor.py
@@ -27,7 +27,7 @@ class TestCursor(IntegrationTestCaseBase):
         for document in reversed(self.documents):
             documents.append(cursor.next())
 
-        assert sorted(documents) == sorted(self.documents)
+        assert sorted(documents, key=lambda doc: doc.get('id')) == self.documents
 
     def test_cursor_empty_no_document(self):
         cursor = self.r.table(self.table_name).run(self.conn)
@@ -63,7 +63,7 @@ class TestCursor(IntegrationTestCaseBase):
         for document in self.r.table(self.table_name).run(self.conn):
             documents.append(document)
 
-        assert sorted(documents) == sorted(self.documents)
+        assert sorted(documents, key=lambda doc: doc.get('id')) == self.documents
 
     def test_next(self):
         self.r.table(self.table_name).insert(self.documents).run(self.conn)


### PR DESCRIPTION
This will help ensure our support is maintained for both Python2 and Python3. It would also point out that #44 breaks this support, so that a review of the release notes would be automatic.