### PR TITLE
Add instruction that was missing from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ In the `Makefile` you can find three different test commands: `test-unit`, `test
 Before you run any test, make sure that you install the requirements.
 ```bash
 $ pip install -r requirements.txt
+$ make prepare
 ```
 
 ### Running unit tests


### PR DESCRIPTION
I am trying to get back up to speed on RethinkDB after not working with it for the last 15 months. A lot of things have changed, wow! Thanks to @gabor-boros and @grandquista for working so hard on this Python driver.

The first thing I noticed is that the README is missing a step: we need to run `make prepare` before we can run the unit tests, so I have added that to the README.