### PR TITLE
logging.basicConfig assumes that log_format is a str

### DIFF
--- a/rethinkdb/logger.py
+++ b/rethinkdb/logger.py
@@ -35,7 +35,7 @@ class DriverLogger(object):
         """
 
         super(DriverLogger, self).__init__()
-        log_format = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+        log_format = '%(asctime)s - %(name)s - %(levelname)s - %(message)s'
         logging.basicConfig(format=log_format)
 
         self.logger = logging.getLogger()


### PR DESCRIPTION
Source: https://docs.python.org/3/library/logging.html

```
FORMAT = '%(asctime)-15s %(clientip)s %(user)-8s %(message)s'
logging.basicConfig(format=FORMAT)
d = {'clientip': '192.168.0.1', 'user': 'fbloggs'}
logger = logging.getLogger('tcpserver')
logger.warning('Protocol problem: %s', 'connection reset', extra=d)
```