### PR TITLE
fix: queries with constants fail to serialize

### DIFF
--- a/rethinkdb/query.py
+++ b/rethinkdb/query.py
@@ -287,13 +287,13 @@ def now(*args):
 
 
 class RqlConstant(ast.RqlQuery):
-    def __init__(self, st, tt):
-        self.st = st
-        self.tt = tt
+    def __init__(self, statement, term_type):
+        self.statement = statement
+        self.term_type = term_type
         super(RqlConstant, self).__init__()
 
     def compose(self, args, optargs):
-        return 'r.' + self.st
+        return 'r.' + self.statement
 
 
 # Time enum values

--- a/tests/integration/test_data_write.py
+++ b/tests/integration/test_data_write.py
@@ -125,6 +125,24 @@ class TestDataWrite(IntegrationTestCaseBase):
         assert response['replaced'] == 1
         assert document == self.insert_data
 
+    def test_query_between_integers(self):
+        self.r.table(self.table_name).insert(self.insert_data).run(self.conn)
+
+        document = next(self.r.table(self.table_name).between(
+            0, self.insert_data["id"] + 1,
+        ).run(self.conn))
+
+        assert document == self.insert_data
+
+    def test_query_between_constants(self):
+        self.r.table(self.table_name).insert(self.insert_data).run(self.conn)
+
+        document = next(self.r.table(self.table_name).between(
+            self.r.minval, self.r.maxval,
+        ).run(self.conn))
+
+        assert document == self.insert_data
+
     def test_update_on_table(self):
         self.r.table(self.table_name).insert(self.insert_data).run(self.conn)
 


### PR DESCRIPTION
Closes #77 

`RqlConstant`'s attributes were not renamed along with the rest of the `RqlQuery` subclasses. This causes queries using them to fail serialization, and raise an `AttributeError`.

Added tests to check for this error in future.

This kind of error could be prevented in future by using [Abstract Base Classes](https://docs.python.org/3/library/abc.html)