### PR TITLE
Add trio_net to setup.py and removed deprecated module

### DIFF
--- a/rethinkdb/trio_net/net_trio.py
+++ b/rethinkdb/trio_net/net_trio.py
@@ -23,7 +23,6 @@ import struct
 
 import trio
 import trio.abc
-import trio.ssl
 
 from rethinkdb import ql2_pb2, RethinkDB
 from rethinkdb.errors import ReqlAuthError, ReqlCursorEmpty, ReqlDriverError, \

--- a/setup.py
+++ b/setup.py
@@ -76,6 +76,7 @@ setuptools.setup(
         'rethinkdb.tornado_net',
         'rethinkdb.twisted_net',
         'rethinkdb.gevent_net',
+        'rethinkdb.trio_net',
         'rethinkdb.backports',
         'rethinkdb.backports.ssl_match_hostname'
     ] + CONDITIONAL_PACKAGES,


### PR DESCRIPTION
Two quick fixes for the Trio driver:

1) Remove a module `trio.ssl` that was deprecated by the Trio project.
2) Add the trio driver to `setup.py`. (I didn't realize that the `setup.py` needed to list those subpackages.)