### PR TITLE
Fix/setup py install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,6 +58,7 @@ test-ci:
 	@killall rebirthdb
 
 test-remote:
+	curl -qo ${REMOTE_TEST_SETUP_NAME} ${REMOTE_TEST_SETUP_URL}
 	python ${REMOTE_TEST_SETUP_NAME} pytest -m integration
 
 install-db:
@@ -82,5 +83,4 @@ clean:
 prepare:
 	curl -qo ${TARGET_PROTO_FILE} ${PROTO_FILE_URL}
 	curl -qo ${FILE_CONVERTER_NAME} ${FILE_CONVERTER_URL}
-	curl -qo ${REMOTE_TEST_SETUP_NAME} ${REMOTE_TEST_SETUP_URL}
 	python ./${FILE_CONVERTER_NAME} -l python -i ${TARGET_PROTO_FILE} -o ${TARGET_CONVERTED_PROTO_FILE}

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ The following examples demonstrate how to use the driver in each mode.
 
 ### Default mode (blocking I/O)
 The driver's default mode of operation is to use blocking I/O, i.e. standard Python
-sockets. This example shows how to create a table, populate with data, and get every 
+sockets. This example shows how to create a table, populate with data, and get every
 document.
 
 ```python
@@ -252,6 +252,7 @@ Remote test will create a new temporary SSH key and a Droplet for you until the 
 | DO_REGION     | sfo2          |
 
 ```bash
+$ pip install paramiko python-digitalocean
 $ export DO_TOKEN=<YOUR_TOKEN>
 $ make test-remote
 ```

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,4 @@ codacy-coverage==1.3.11
 mock==2.0.0
 pytest-cov==2.6.1
 pytest==4.3.0
-paramiko==2.4.2
-python-digitalocean==1.13.2
 six==1.12.0

--- a/rethinkdb/__init__.py
+++ b/rethinkdb/__init__.py
@@ -12,12 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import os
-
 import imp
+import pkg_resources
 
 from rethinkdb import errors, version
-from rethinkdb import net
-import pkg_resources
 
 
 # The builtins here defends against re-importing something obscuring `object`.
@@ -35,7 +33,16 @@ class RethinkDB(builtins.object):
     def __init__(self):
         super(RethinkDB, self).__init__()
 
-        from rethinkdb import _dump, _export, _import, _index_rebuild, _restore, ast, query, net
+        from rethinkdb import (
+            _dump,
+            _export,
+            _import,
+            _index_rebuild,
+            _restore,
+            ast,
+            query,
+            net
+        )
 
         self._dump = _dump
         self._export = _export

--- a/setup.py
+++ b/setup.py
@@ -94,7 +94,9 @@ setuptools.setup(
             'rethinkdb-repl = rethinkdb.__main__:startInterpreter'
         ]
     },
-    setup_requires=['pytest-runner'],
-    test_suite='tests',
-    tests_require=['pytest']
+    python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*",
+    install_requires=[
+        'six'
+    ],
+    test_suite='tests'
 )


### PR DESCRIPTION
## Description
Fixing the setup.py install for `pip` and `python setup.py install`. Please note that I also removed paramiko and digitalocean as dependencies, due to they are not required and only needed for the remote integration test running. The readme adjusted.