### PR TITLE
Helping developers to upgrade to 2.4.x easier

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,9 @@ main().addCallback(lambda d: print("stopping") or reactor.stop())
 reactor.run()
 ```
 
+## Misc
+Although we recommend to use the import used in the examples, to help the migration from rethinkdb<2.4 we introduced a shortcut which can easily replace the old `import rethinkdb as r` import with `from rethinkdb import r`. 
+
 ## Run tests
 In the `Makefile` you can find three different test commands: `test-unit`, `test-integration` and `test-remote`. As RethinkDB has dropped the support of Windows, we would like to ensure that those of us who are using Windows for development can still contribute. Because of this, we support running integration tests against Digital Ocean Droplets as well.
 

--- a/rethinkdb/__init__.py
+++ b/rethinkdb/__init__.py
@@ -83,3 +83,6 @@ class RethinkDB(builtins.object):
 
     def connect(self, *args, **kwargs):
         return self.make_connection(self.connection_type, *args, **kwargs)
+
+
+r = RethinkDB()


### PR DESCRIPTION
## Description
Those developers who has a lot of reference to the old import has hard times
migrating to the new package. To help them, we are introducing a shortcut for
`from rethinkdb import Retinkdb; r = Rethinkdb()`, so they can import the it as
`from rethinkdb import r`. Now they can easily find-and-replace the imports.

## Note
The import in 2.3 looked like `import rethinkdb as r`.

## Related issue 
Issue https://github.com/rethinkdb/rethinkdb-python/issues/96