### PR TITLE
Fix StopIteration exception related issue

### DIFF
--- a/rethinkdb/errors.py
+++ b/rethinkdb/errors.py
@@ -248,7 +248,7 @@ class T(object):
             for sub in next(itr):
                 yield sub
         except StopIteration:
-                    return
+            return
 
         for token in itr:
             for sub in self.intsp:

--- a/rethinkdb/errors.py
+++ b/rethinkdb/errors.py
@@ -243,10 +243,16 @@ class T(object):
 
     def __iter__(self):
         itr = iter(self.seq)
-        for sub in next(itr):
-            yield sub
+
+        try:
+            for sub in next(itr):
+                yield sub
+        except StopIteration:
+                    return
+
         for token in itr:
             for sub in self.intsp:
                 yield sub
+
             for sub in token:
                 yield sub

--- a/tests/integration/test_date_and_time.py
+++ b/tests/integration/test_date_and_time.py
@@ -1,0 +1,46 @@
+import pytest
+from copy import deepcopy
+from tests.helpers import IntegrationTestCaseBase
+
+
+@pytest.mark.integration
+class TestDateAndTime(IntegrationTestCaseBase):
+    def setup_method(self):
+        super(TestDateAndTime, self).setup_method()
+        self.table_name = 'test_now'
+        self.r.table_create(self.table_name).run(self.conn)
+
+        self.expected_insert_response = {
+            'deleted': 0,
+            'errors': 0,
+            'inserted': 1,
+            'replaced': 0,
+            'skipped': 0,
+            'unchanged': 0,
+        }
+
+    @staticmethod
+    def compare_seconds(a, b):
+        """
+        During the tests, the milliseconds are a little different, so we need to look at the results in seconds.
+        """
+        def second_precision(dt):
+            return str(dt).split('.')[0]
+
+        assert second_precision(a) == second_precision(b)
+
+    def test_insert_with_now(self):
+        now = self.r.now()
+        insert_data = {
+            'id': 1,
+            'name': 'Captain America',
+            'real_name': 'Steven Rogers',
+            'universe': 'Earth-616',
+            'created_at': now
+        }
+
+        response = self.r.table(self.table_name).insert(insert_data).run(self.conn)
+        document = self.r.table(self.table_name).get(1).run(self.conn)
+
+        assert response == self.expected_insert_response
+        self.compare_seconds(document['created_at'], self.r.now().run(self.conn))

--- a/tests/test_date_and_time.py
+++ b/tests/test_date_and_time.py
@@ -1,0 +1,13 @@
+import pytest
+from mock import call, patch, ANY, Mock
+from rethinkdb import r, ast
+
+
+@pytest.mark.unit
+class TestNow(object):
+    def setup_method(self):
+        pass
+
+    def test_get_now(self):
+        now = r.now()
+        assert type(now) == ast.Now


### PR DESCRIPTION
**Reason for the change**
https://github.com/rethinkdb/rethinkdb-python/issues/110

**Description**
Due to PEP 479 StopIteration handling inside generators. This change fixes the "issue" by returning if a stop iteration raised.

**Code examples**
```python
Python 3.7.3 (default, Mar 27 2019, 09:23:15) 
[Clang 10.0.1 (clang-1001.0.46.3)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> from rethinkdb import r
>>> r.now()
<RqlQuery instance: r.now() >
```

**Checklist**
- [x] Unit tests created/modified
- [x] Integration tests created/modified

**References**
https://www.python.org/dev/peps/pep-0479/
