### PR TITLE
Fix command line parser for dump/import/export commands

### DIFF
--- a/rethinkdb/_dump.py
+++ b/rethinkdb/_dump.py
@@ -66,6 +66,7 @@ def parse_options(argv, prog=None):
         dest="db_tables",
         metavar="DB|DB.TABLE",
         default=[],
+        type='db_table',
         help='limit dump to the given database or table (may be specified multiple times)',
         action="append")
 

--- a/rethinkdb/utils_common.py
+++ b/rethinkdb/utils_common.py
@@ -161,7 +161,7 @@ class CommonOptionsParser(optparse.OptionParser, object):
             else:
                 raise optparse.OptionValueError('Option %s value is not a file: %r' % (opt_str, value))
 
-        def check_db_table_option(_, opt_str, value):
+        def check_db_table_option(_, _opt_str, value):
             res = _tableNameRegex.match(value)
 
             if not res:

--- a/rethinkdb/utils_common.py
+++ b/rethinkdb/utils_common.py
@@ -172,10 +172,14 @@ class CommonOptionsParser(optparse.OptionParser, object):
             return DbTable(res.group('db'), res.group('table'))
 
         def check_positive_int(_, opt_str, value):
-            if not isinstance(value, int) or value < 1:
-                raise optparse.OptionValueError('%s value must be an integer greater that 1: %s' % (opt_str, value))
+            try:
+                value = int(value)
+                if value < 1:
+                    raise ValueError
+            except ValueError:
+                raise optparse.OptionValueError('%s value must be an integer greater than 1: %s' % (opt_str, value))
 
-            return int(value)
+            return value
 
         def check_existing_file(_, opt_str, value):
             if not os.path.isfile(value):

--- a/rethinkdb/utils_common.py
+++ b/rethinkdb/utils_common.py
@@ -153,7 +153,7 @@ class CommonOptionsParser(optparse.OptionParser, object):
     def __init__(self, *args, **kwargs):
         # -- Type Checkers
 
-        def check_tls_option(opt_str, value):
+        def check_tls_option(_, opt_str, value):
             value = str(value)
 
             if os.path.isfile(value):
@@ -161,7 +161,7 @@ class CommonOptionsParser(optparse.OptionParser, object):
             else:
                 raise optparse.OptionValueError('Option %s value is not a file: %r' % (opt_str, value))
 
-        def check_db_table_option(value):
+        def check_db_table_option(_, opt_str, value):
             res = _tableNameRegex.match(value)
 
             if not res:
@@ -171,7 +171,7 @@ class CommonOptionsParser(optparse.OptionParser, object):
 
             return DbTable(res.group('db'), res.group('table'))
 
-        def check_positive_int(opt_str, value):
+        def check_positive_int(_, opt_str, value):
             if not isinstance(value, int) or value < 1:
                 raise optparse.OptionValueError('%s value must be an integer greater that 1: %s' % (opt_str, value))
 
@@ -183,7 +183,7 @@ class CommonOptionsParser(optparse.OptionParser, object):
 
             return os.path.realpath(value)
 
-        def check_new_file_location(opt_str, value):
+        def check_new_file_location(_, opt_str, value):
             try:
                 real_value = os.path.realpath(value)
             except Exception:
@@ -194,7 +194,7 @@ class CommonOptionsParser(optparse.OptionParser, object):
 
             return real_value
 
-        def file_contents(opt_str, value):
+        def file_contents(_, opt_str, value):
             if not os.path.isfile(value):
                 raise optparse.OptionValueError('%s value is not an existing file: %r' % (opt_str, value))
 

--- a/tests/test_utils_common.py
+++ b/tests/test_utils_common.py
@@ -1,0 +1,73 @@
+import pytest
+from rethinkdb import utils_common
+
+
+@pytest.fixture
+def parser():
+    opt_parser = utils_common.CommonOptionsParser()
+    opt_parser.add_option(
+        "-e",
+        "--export",
+        dest="db_tables",
+        metavar="DB|DB.TABLE",
+        default=[],
+        type='db_table',
+        action="append")
+    opt_parser.add_option(
+        "--clients",
+        dest="clients",
+        metavar="NUM",
+        default=3,
+        type="pos_int")
+    return opt_parser
+
+
+def test_option_parser_int_pos(parser):
+    options, args = parser.parse_args(['--clients', '4'], connect=False)
+
+    assert options.clients == 4
+
+
+def test_option_parser_int_pos_equals(parser):
+    options, args = parser.parse_args(['--clients=4'], connect=False)
+
+    assert options.clients == 4
+
+
+def test_option_parser_int_pos_default(parser):
+    options, args = parser.parse_args([], connect=False)
+
+    assert options.clients == 3
+
+
+def test_option_parser_int_pos_fail(parser):
+    with pytest.raises(SystemExit):
+        parser.parse_args(['--clients=asdf'], connect=False)
+
+
+def test_option_parser_int_pos_zero(parser):
+    with pytest.raises(SystemExit):
+        parser.parse_args(['--clients=0'], connect=False)
+
+
+def test_option_parser_db_table(parser):
+    options, args = parser.parse_args(['--export=example.table'], connect=False)
+
+    assert options.db_tables == [('example', 'table')]
+
+
+def test_option_parser_db_table_append(parser):
+    options, args = parser.parse_args(['--export=example.table', '--export=example.another'], connect=False)
+
+    assert options.db_tables == [('example', 'table'), ('example', 'another')]
+
+
+def test_option_parser_db_table_only_db(parser):
+    options, args = parser.parse_args(['--export=example'], connect=False)
+
+    assert options.db_tables == [('example', None)]
+
+
+def test_option_parser_db_table_fail(parser):
+    with pytest.raises(SystemExit):
+        parser.parse_args(['--export='], connect=False)


### PR DESCRIPTION
**Motivation**: all versions of rethinkdb python driver above 2.3.0.post6 have problems with export-import functionality - examples of backup/recovery from the docs don't work. Just try something like `python -m rethinkdb dump -e example.table -f rdb.tar.gz` or `rethinkdb import -c localhost:28015 -i example -d ./rethinkdb_export --force --clients=2`

**Description**: These patches contain only obvious bug fixes in `utils_common.CommonOptionsParser` command line parser for `dump/export/import` commands
