### PR TITLE
Fix cursor recovery during export

### DIFF
--- a/rethinkdb/_export.py
+++ b/rethinkdb/_export.py
@@ -351,7 +351,7 @@ def export_table(db, table, directory, options, error_queue, progress_info, sind
                 cursor = options.retryQuery(
                     'backup cursor for %s.%s' %
                     (db, table), query.db(db).table(table).between(
-                        lastPrimaryKey, None, left_bound="open").order_by(
+                        lastPrimaryKey, query.maxval, left_bound="open").order_by(
                         index=table_info["primary_key"]), run_options=run_options)
 
     except (errors.ReqlError, errors.ReqlDriverError) as ex:


### PR DESCRIPTION
**Motivation**
During export table if connection breaks, then it tries to restore the cursor by using `between` operation. But there is a simple rql syntax error and it raises the following exception:

    rethinkdb.errors.ReqlQueryLogicError: Cannot use `null` in BETWEEN, use `r.minval` or `r.maxval` to denote unboundedness in... 

**Description**
`None` is incorrect param for `between` operation, so it should be `r.maxval` for the right bound. Note, it's quite hard to provide a unit-test for this functionality 