### PR TITLE
Fix write-hook compatiblity for 2.3.6 (import/export)

### DIFF
--- a/rethinkdb/_export.py
+++ b/rethinkdb/_export.py
@@ -234,6 +234,8 @@ def export_table(db, table, directory, options, error_queue, progress_info, sind
 
     writer = None
 
+    has_write_hooks = utils_common.check_minimum_version(options, '2.3.7', False)
+
     try:
         # -- get table info
 
@@ -248,13 +250,14 @@ def export_table(db, table, directory, options, error_queue, progress_info, sind
 
         sindex_counter.value += len(table_info["indexes"])
 
-        table_info['write_hook'] = options.retryQuery(
-            'table write hook data %s.%s' % (db, table),
-            query.db(db).table(table).get_write_hook(),
-            run_options={'binary_format': 'raw'})
+        if has_write_hooks:
+            table_info['write_hook'] = options.retryQuery(
+                'table write hook data %s.%s' % (db, table),
+                query.db(db).table(table).get_write_hook(),
+                run_options={'binary_format': 'raw'})
 
-        if table_info['write_hook'] is not None:
-            hook_counter.value += 1
+            if table_info['write_hook'] is not None:
+                hook_counter.value += 1
 
         with open(os.path.join(directory, db, table + '.info'), 'w') as info_file:
             info_file.write(json.dumps(table_info) + "\n")

--- a/rethinkdb/utils_common.py
+++ b/rethinkdb/utils_common.py
@@ -124,7 +124,7 @@ def print_progress(ratio, indent=0, read=None, write=None):
     sys.stdout.flush()
 
 
-def check_minimum_version(options, minimum_version='1.6'):
+def check_minimum_version(options, minimum_version='1.6', raise_exception=True):
     minimum_version = distutils.version.LooseVersion(minimum_version)
     version_string = options.retryQuery('get server version', query.db(
         'rethinkdb').table('server_status')[0]['process']['version'])
@@ -135,7 +135,10 @@ def check_minimum_version(options, minimum_version='1.6'):
         raise RuntimeError("invalid version string format: %s" % version_string)
 
     if distutils.version.LooseVersion(matches.group('version')) < minimum_version:
-        raise RuntimeError("Incompatible version, expected >= %s got: %s" % (minimum_version, version_string))
+        if raise_exception:
+            raise RuntimeError("Incompatible version, expected >= %s got: %s" % (minimum_version, version_string))
+        return False
+    return True
 
 
 DbTable = collections.namedtuple('DbTable', ['db', 'table'])


### PR DESCRIPTION
**Reason for the change**
Write-hooks is the only feature that blocks usage of dump/import/export commands of newest rethinkdb drivers with database version `2.3.6` although it's easy to make that backward-compatible

**Description**
It is needed to check minimal database version and if lower than `2.3.7` then disable reading/writing of write-hooks during export/import.