### PR TITLE
Fix StopIteration in the case of EOF (import/restore)

### DIFF
--- a/rethinkdb/_import.py
+++ b/rethinkdb/_import.py
@@ -372,9 +372,6 @@ class SourceFile(object):
             if self.indexes:
                 self.restore_indexes(warning_queue)
 
-            # -
-            raise e
-
     def setup_file(self, warning_queue=None):
         raise NotImplementedError("Subclasses need to implement this")
 


### PR DESCRIPTION
**Reason for the change**
Import/restore doesn't work without this patch

**Description**
The proper way is `return`, not `raise StopIteration`.

**References**
https://www.python.org/dev/peps/pep-0479/