### PR TITLE
Fix dump command

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,6 @@
 [pytest]
 python_files = test_*.py
+markers =
+    unit: Run unit tests
+    integration: Run integration tests
+    asyncio: Run asyncio relates tests

--- a/rethinkdb/_dump.py
+++ b/rethinkdb/_dump.py
@@ -18,7 +18,7 @@
 # Copyright 2010-2016 RethinkDB, all rights reserved.
 
 
-'''`rethinkdb dump` creates an archive of data from a RethinkDB cluster'''
+'''`rethinkdb-dump` creates an archive of data from a RethinkDB cluster'''
 
 from __future__ import print_function
 
@@ -95,7 +95,6 @@ def parse_options(argv, prog=None):
     options, args = parser.parse_args(argv)
 
     # Check validity of arguments
-
     if len(args) != 0:
         raise parser.error("No positional arguments supported. Unrecognized option(s): %s" % args)
 
@@ -141,7 +140,7 @@ def parse_options(argv, prog=None):
 
 
 def main(argv=None, prog=None):
-    options = parse_options(argv or sys.argv[2:], prog=prog)
+    options = parse_options(argv or sys.argv[1:], prog=prog)
     try:
         if not options.quiet:
             # Print a warning about the capabilities of dump, so no one is confused (hopefully)


### PR DESCRIPTION
**Reason for the change**
https://github.com/rethinkdb/rethinkdb-python/issues/137

**Description**
As it turned out, all the commands receiving the parameters like `sys.argv[1:]` except the dump command. Because of this, the command ignored the first parameter which is usually the `--connect` so the users were not able to connect to their RethinkDB servers.

***Note***
*This PR also contains some adjustments for pytest's config. The Unit/integration tests are missing right now for all the commands, but we will need to include them later.*

**Code examples**
Run the script as a python script
`python -m rethinkdb dump -c localhost:28015`

Run the script as an installed script
`rethinkdb-dump -c localhost:28015`

**References**
Related issues in the past: 
- #104 
