### PR TITLE
MANIFEST.in: Include LICENSE and tests in sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,8 @@
+include LICENSE
+include *.txt
+include Makefile
+include pytest.ini
+include .coveragerc
+recursive-include scripts *.py
+recursive-include scripts *.sh
+recursive-include tests *.py


### PR DESCRIPTION
**Reason for the change**
Packaging requires a LICENSE file, and benefits greatly from
having test infrastructure to validate the built library.

**Description**
Created a MANIFEST.in to include LICENSE and tests in the sdist
uploaded to PyPi.

**Code examples**

**Checklist**

**References**