### PR TITLE
Add write hook tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,14 +32,15 @@ default: help
 help:
 	@echo "Usage:"
 	@echo
-	@echo "	make help				Print this help message"
-	@echo "	make test-unit			Run unit tests"
-	@echo "	make test-integration	Run integration tests"
-	@echo "	make test-remote		Run tests on digital ocean"
-	@echo "	make upload-coverage	Upload unit test coverage"
-	@echo "	make upload-pypi		Release ${PACKAGE_NAME} package to PyPi"
-	@echo "	make clean				Cleanup source directory"
-	@echo "	make prepare			Prepare ${PACKAGE_NAME} for build"
+	@echo "	make help				    Print this help message"
+	@echo "	make test-unit			    Run unit tests"
+	@echo "	make test-integration	    Run integration tests"
+	@echo "	make test-integration-2.4	Run integration tests"
+	@echo "	make test-remote		    Run tests on digital ocean"
+	@echo "	make upload-coverage	    Upload unit test coverage"
+	@echo "	make upload-pypi		    Release ${PACKAGE_NAME} package to PyPi"
+	@echo "	make clean				    Cleanup source directory"
+	@echo "	make prepare			    Prepare ${PACKAGE_NAME} for build"
 
 test-unit:
 	pytest -v -m unit
@@ -47,6 +48,11 @@ test-unit:
 test-integration:
 	@rethinkdb&
 	pytest -v -m integration
+	@killall rethinkdb
+
+test-integration-2.4:
+	@rethinkdb&
+	pytest -v -m integration_v2_4_x
 	@killall rethinkdb
 
 test-ci:

--- a/Makefile
+++ b/Makefile
@@ -51,9 +51,7 @@ test-integration:
 	@killall rethinkdb
 
 test-integration-2.4:
-	@rethinkdb&
 	pytest -v -m integration_v2_4_x
-	@killall rethinkdb
 
 test-ci:
 	@rethinkdb&

--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ test-integration-2.4:
 
 test-ci:
 	@rethinkdb&
-	pytest -v --cov rethinkdb --cov-report xml
+	pytest -v --cov rethinkdb --cov-report xml --ignore=tests/integration/test_write_hooks.py
 	@killall rethinkdb
 
 test-remote:

--- a/pytest.ini
+++ b/pytest.ini
@@ -3,6 +3,7 @@ python_files = test_*.py
 markers =
     unit: Run unit tests
     integration: Run integration tests
+    integration_v2_4_x: Run 2.4.x only integration tests
     trio: Run trio related tests
     tornado: Run tornado related tests
     asyncio: Run asyncio related tests

--- a/tests/integration/test_write_hooks.py
+++ b/tests/integration/test_write_hooks.py
@@ -1,0 +1,42 @@
+import pytest
+
+from tests.helpers import IntegrationTestCaseBase
+
+@pytest.mark.integration_v2_4_x
+class TestWriteHooks(IntegrationTestCaseBase):
+    def setup_method(self):
+        super(TestWriteHooks, self).setup_method()
+
+        self.table_name = 'test_write_hooks'
+        self.documents = [
+            {'id': 1, 'name': 'Testing write hooks 1'},
+        ]
+
+        self.r.table_create(self.table_name).run(self.conn)
+        self.r.table(self.table_name).insert(self.documents).run(self.conn)
+
+    def test_set_write_hook(self):
+        self.r.table(self.table_name).set_write_hook(lambda context, old_val, new_val:
+            new_val.merge({
+                'modified_at': context['timestamp']
+            })
+        ).run(self.conn)
+
+        hook = self.r.table(self.table_name).get_write_hook().run(self.conn)
+
+        assert hook.keys() == ['function', 'query']
+
+    def test_write_hook_add_extra_data(self):
+        self.r.table(self.table_name).set_write_hook(lambda context, old_val, new_val:
+            new_val.merge({
+                'modified_at': context['timestamp']
+            })
+        ).run(self.conn)
+
+        self.r.table(self.table_name).insert({
+            'id': 2, 'name': 'Testing write hooks 1'
+        }).run(self.conn)
+
+        document = self.r.table(self.table_name).get(2).run(self.conn)
+
+        assert document.get('modified_at') != None

--- a/tests/integration/test_write_hooks.py
+++ b/tests/integration/test_write_hooks.py
@@ -16,15 +16,13 @@ class TestWriteHooks(IntegrationTestCaseBase):
         self.r.table(self.table_name).insert(self.documents).run(self.conn)
 
     def test_set_write_hook(self):
-        self.r.table(self.table_name).set_write_hook(lambda context, old_val, new_val:
+        response = self.r.table(self.table_name).set_write_hook(lambda context, old_val, new_val:
             new_val.merge({
                 'modified_at': context['timestamp']
             })
         ).run(self.conn)
 
-        hook = self.r.table(self.table_name).get_write_hook().run(self.conn)
-
-        assert hook.keys() == ['function', 'query']
+        assert response == {'created': 1}
 
     def test_write_hook_add_extra_data(self):
         self.r.table(self.table_name).set_write_hook(lambda context, old_val, new_val:
@@ -40,3 +38,14 @@ class TestWriteHooks(IntegrationTestCaseBase):
         document = self.r.table(self.table_name).get(2).run(self.conn)
 
         assert document.get('modified_at') != None
+
+    def test_get_write_hook(self):
+        self.r.table(self.table_name).set_write_hook(lambda context, old_val, new_val:
+            new_val.merge({
+                'modified_at': context['timestamp']
+            })
+        ).run(self.conn)
+
+        hook = self.r.table(self.table_name).get_write_hook().run(self.conn)
+
+        assert list(hook.keys()) == ['function', 'query']


### PR DESCRIPTION
**Reason for the change**
Write hook integration tests are missing from the python driver against v2.4.x

**Description**
Add integration tests for 2.4.x and mark them with a special tag not to confuse others. Also, this tag will be merged with the original integration test marker and will be added to the pipeline in the future. Until that we run the test manually.

**Code examples**
-

**Checklist**
- [ ] Unit tests created/modified
- [x] Integration tests created/modified

**References**
https://github.com/rethinkdb/docs/pull/1241
