### PR TITLE
Implement DB URL connection support

### DIFF
--- a/rethinkdb/net.py
+++ b/rethinkdb/net.py
@@ -725,11 +725,10 @@ def make_connection(
         connection_string = urlparse(url)
         query_string = parse_qs(connection_string.query)
         
-        # Reverse the tuple, this way we can ensure that the host:port/user:pass
-        # will be always at the same position
-        host_port, _, user_pass = connection_string.netloc.partition("@")[::-1]
-        user, password = user_pass.partition(":")[0], user_pass.partition(":")[2]
-        host, port = host_port.partition(":")[0], host_port.partition(":")[2]
+        user = connection_string.username
+        password = connection_string.password
+        host = connection_string.hostname
+        port = connection_string.port
 
         db = connection_string.path.replace("/", "") or None
         auth_key = query_string.get("auth_key")

--- a/rethinkdb/net.py
+++ b/rethinkdb/net.py
@@ -724,7 +724,7 @@ def make_connection(
     if url:
         connection_string = urlparse(url)
         query_string = parse_qs(connection_string.query)
-        
+
         user = connection_string.username
         password = connection_string.password
         host = connection_string.hostname

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -6,18 +6,21 @@ INTEGRATION_TEST_DB = 'integration_test'
 
 
 class IntegrationTestCaseBase(object):
+    def _create_database(self, conn):
+        if INTEGRATION_TEST_DB not in self.r.db_list().run(conn):
+            self.r.db_create(INTEGRATION_TEST_DB).run(conn)
+
+        conn.use(INTEGRATION_TEST_DB)
+
     def setup_method(self):
         self.r = r
-        self.rethinkdb_host = os.getenv('RETHINKDB_HOST')
+        self.rethinkdb_host = os.getenv('RETHINKDB_HOST', '127.0.0.1')
 
         self.conn = self.r.connect(
             host=self.rethinkdb_host
         )
 
-        if INTEGRATION_TEST_DB not in self.r.db_list().run(self.conn):
-            self.r.db_create(INTEGRATION_TEST_DB).run(self.conn)
-
-        self.conn.use(INTEGRATION_TEST_DB)
+        self._create_database(self.conn)
 
     def teardown_method(self):
         self.r.db_drop(INTEGRATION_TEST_DB).run(self.conn)

--- a/tests/integration/test_connect.py
+++ b/tests/integration/test_connect.py
@@ -1,0 +1,29 @@
+import os
+import pytest
+
+from rethinkdb import r
+from tests.helpers import IntegrationTestCaseBase, INTEGRATION_TEST_DB
+
+
+@pytest.mark.integration
+class TestConnect(IntegrationTestCaseBase):
+    def setup_method(self):
+        super(TestConnect, self).setup_method()
+
+    def test_connect(self):
+        db_url = "rethinkdb://{host}".format(host=self.rethinkdb_host)
+
+        assert self.r.connect(url=db_url) is not None
+
+    def test_connect_with_username(self):
+        db_url = "rethinkdb://admin@{host}".format(host=self.rethinkdb_host)
+
+        assert self.r.connect(url=db_url) is not None
+
+    def test_connect_to_db(self):
+        db_url = "rethinkdb://{host}/{database}".format(
+            host=self.rethinkdb_host,
+            database=INTEGRATION_TEST_DB
+        )
+
+        assert self.r.connect(url=db_url) is not None

--- a/tests/integration/test_write_hooks.py
+++ b/tests/integration/test_write_hooks.py
@@ -48,4 +48,4 @@ class TestWriteHooks(IntegrationTestCaseBase):
 
         hook = self.r.table(self.table_name).get_write_hook().run(self.conn)
 
-        assert list(hook.keys()) == ['function', 'query']
+        assert list(sorted(hook.keys())) == ['function', 'query']

--- a/tests/test_net.py
+++ b/tests/test_net.py
@@ -1,0 +1,200 @@
+import pytest
+from mock import Mock, ANY
+from rethinkdb.net import make_connection, DefaultConnection, DEFAULT_PORT
+
+
+@pytest.mark.unit
+class TestMakeConnection(object):
+    def setup_method(self):
+        self.reconnect = Mock()
+        self.conn_type = Mock()
+        self.conn_type.return_value.reconnect.return_value = self.reconnect
+
+        self.host = "myhost"
+        self.port = "1234"
+        self.db = "mydb"
+        self.auth_key = None
+        self.user = "gabor"
+        self.password = "strongpass"
+        self.timeout = 20
+
+
+    def test_make_connection(self):
+        ssl = dict()
+        _handshake_version = 10
+
+        conn = make_connection(
+            self.conn_type,
+            host=self.host,
+            port=self.port,
+            db=self.db,
+            auth_key=self.auth_key,
+            user=self.user,
+            password=self.password,
+            timeout=self.timeout,
+        )
+
+        assert conn == self.reconnect
+        self.conn_type.assert_called_once_with(
+            self.host,
+            self.port,
+            self.db,
+            self.auth_key,
+            self.user,
+            self.password,
+            self.timeout,
+            ssl,
+            _handshake_version
+        )
+
+
+    def test_make_connection_db_url(self):
+        url = "rethinkdb://gabor:strongpass@myhost:1234/mydb?auth_key=mykey&timeout=30"
+        ssl = dict()
+        _handshake_version = 10
+
+        conn = make_connection(self.conn_type, url=url)
+
+        assert conn == self.reconnect
+        self.conn_type.assert_called_once_with(
+            self.host,
+            self.port,
+            self.db,
+            "mykey",
+            self.user,
+            self.password,
+            30,
+            ssl,
+            _handshake_version
+        )
+
+
+    def test_make_connection_no_host(self):
+        conn = make_connection(
+            self.conn_type,
+            port=self.port,
+            db=self.db,
+            auth_key=self.auth_key,
+            user=self.user,
+            password=self.password,
+            timeout=self.timeout,
+        )
+
+        assert conn == self.reconnect
+        self.conn_type.assert_called_once_with(
+            "localhost",
+            self.port,
+            self.db,
+            self.auth_key,
+            self.user,
+            self.password,
+            self.timeout,
+            ANY,
+            ANY
+        )
+
+
+    def test_make_connection_no_port(self):
+        conn = make_connection(
+            self.conn_type,
+            host=self.host,
+            db=self.db,
+            auth_key=self.auth_key,
+            user=self.user,
+            password=self.password,
+            timeout=self.timeout,
+        )
+
+        assert conn == self.reconnect
+        self.conn_type.assert_called_once_with(
+            self.host,
+            DEFAULT_PORT,
+            self.db,
+            self.auth_key,
+            self.user,
+            self.password,
+            self.timeout,
+            ANY,
+            ANY
+        )
+
+
+    def test_make_connection_no_user(self):
+        conn = make_connection(
+            self.conn_type,
+            host=self.host,
+            port=self.port,
+            db=self.db,
+            auth_key=self.auth_key,
+            password=self.password,
+            timeout=self.timeout,
+        )
+
+        assert conn == self.reconnect
+        self.conn_type.assert_called_once_with(
+            self.host,
+            self.port,
+            self.db,
+            self.auth_key,
+            "admin",
+            self.password,
+            self.timeout,
+            ANY,
+            ANY
+        )
+
+
+    def test_make_connection_with_ssl(self):
+        ssl = dict()
+
+        conn = make_connection(
+            self.conn_type,
+            host=self.host,
+            port=self.port,
+            db=self.db,
+            auth_key=self.auth_key,
+            user=self.user,
+            password=self.password,
+            timeout=self.timeout,
+            ssl=ssl,
+        )
+
+        assert conn == self.reconnect
+        self.conn_type.assert_called_once_with(
+            self.host,
+            self.port,
+            self.db,
+            self.auth_key,
+            self.user,
+            self.password,
+            self.timeout,
+            ssl,
+            ANY
+        )
+
+
+    def test_make_connection_different_handshake_version(self):
+        conn = make_connection(
+            self.conn_type,
+            host=self.host,
+            port=self.port,
+            db=self.db,
+            auth_key=self.auth_key,
+            user=self.user,
+            password=self.password,
+            timeout=self.timeout,
+            _handshake_version=20,
+        )
+
+        assert conn == self.reconnect
+        self.conn_type.assert_called_once_with(
+            self.host,
+            self.port,
+            self.db,
+            self.auth_key,
+            self.user,
+            self.password,
+            self.timeout,
+            ANY,
+            20
+        )

--- a/tests/test_net.py
+++ b/tests/test_net.py
@@ -11,7 +11,7 @@ class TestMakeConnection(object):
         self.conn_type.return_value.reconnect.return_value = self.reconnect
 
         self.host = "myhost"
-        self.port = "1234"
+        self.port = 1234
         self.db = "mydb"
         self.auth_key = None
         self.user = "gabor"


### PR DESCRIPTION
**Reason for the change**
This PR is related to rethinkdb/rethinkdb#4101.

**Description**
Add DB connection URL support.

**Code examples**

```python
>>> from rethinkdb import r
>>> url = "rethinkdb://admin@127.0.0.1:28015/test?timeout=30"
>>> conn = r.connect(url=url)
>>> r.table_create('marvel').run(conn)
{'config_changes': [{'new_val': {'db': 'test', 'durability': 'hard', 'id': '57d565e9-55ca-42f8-85e6-792068ad4a52', 'indexes': [], 'name': 'mar
vel', 'primary_key': 'id', 'shards': [{'nonvoting_replicas': [], 'primary_replica': 'gabor_local_umw', 'replicas': ['gabor_local_umw']}], 'wri
te_acks': 'majority', 'write_hook': None}, 'old_val': None}], 'tables_created': 1}
```

**Checklist**
- [x] Unit tests created/modified
- [x] Integration tests created/modified

**References**
-