### PR TITLE
Fixing import command no primary key issue

### DIFF
--- a/rethinkdb/_import.py
+++ b/rethinkdb/_import.py
@@ -146,7 +146,11 @@ class SourceFile(object):
         self.write_hook = write_hook or []
 
         # options
-        self.source_options = source_options or {}
+        self.source_options = source_options or {
+            "create_args": {
+                "primary_key": self.primary_key
+            }
+        }
 
         # name
         if hasattr(self._source, 'name') and self._source.name:
@@ -249,7 +253,7 @@ class SourceFile(object):
             ast.expr([self.table]).set_difference(
                 query.db(self.db).table_list()
             ).for_each(query.db(self.db).table_create(
-                query.row, **self.source_options.create_args if 'create_args' in self.source_options else {})
+                query.row, **self.source_options["create_args"] if 'create_args' in self.source_options else {})
             )
         )
 


### PR DESCRIPTION
**Reason for the change**
Restoring doesn't pick up primary_key from info files.

**Description**
In turned out that the primary key was parsed from the info file, but not used at table creation at all, hence the table was created with the default primary key `id`. The issue was introduced right after `2.3.0.post6` was released in 2016.

**Code examples**
N/A

**Checklist**
The whole command structure must be tested. Issue for the problem: https://github.com/rethinkdb/rethinkdb-python/issues/172
~~- [ ] Unit tests created/modified~~
~~- [ ] Integration tests created/modified~~

**References**
fixes https://github.com/rethinkdb/rethinkdb-python/issues/171
fixes https://github.com/rethinkdb/rethinkdb-python/issues/157