### PR TITLE
net: do not close socket on EWOULDBLOCK, as this can happen during cursor iteration

### DIFF
--- a/rethinkdb/net.py
+++ b/rethinkdb/net.py
@@ -431,7 +431,6 @@ class SocketWrapper(object):
                         self.close()
                         raise ReqlDriverError("Connection is closed.")
                     elif ex.errno == errno.EWOULDBLOCK:
-                        self.close()
                         # This should only happen with a timeout of 0
                         raise ReqlTimeoutError(self.host, self.port)
                     elif ex.errno != errno.EINTR:


### PR DESCRIPTION
**Reason for the change**

When calling `.next(wait=False)` on a cursor, `ReqlTimeoutError` is raised if the query would block. This is expected and documented behaviour.

However, introduced in 9fbd6f2, this will also close the underlying socket, preventing `.next()` from being called again on the cursor.

This is unexpected behaviour; we would like to be able to continue listening for new changes in a cursor, even after one request has timed out.

**Description**

- `net`: Do not close underlying socket connection if `EWOULDBLOCK` received
- `tests/integration`: Add test case that reproduces the issue (fails against master)

**Code examples**

See the added test for an example.

**Checklist**
- [ ] ~Unit tests created/modified~ **N/A**
- [x] Integration tests created/modified

**References**

Documentation detailing the behaviour of `next` and `wait` can be found here: https://rethinkdb.com/api/python/next/
