### PR TITLE
Allowing dash in DB and table name when using backup tool.

### DIFF
--- a/rethinkdb/utils_common.py
+++ b/rethinkdb/utils_common.py
@@ -170,7 +170,7 @@ def check_minimum_version(options, minimum_version="1.6", raise_exception=True):
 
 
 DbTable = collections.namedtuple("DbTable", ["db", "table"])
-_tableNameRegex = re.compile(r"^(?P<db>\w+)(\.(?P<table>\w+))?$")
+_tableNameRegex = re.compile(r"^(?P<db>[\w-]+)(\.(?P<table>[\w-]+))?$")
 
 
 class CommonOptionsParser(optparse.OptionParser, object):


### PR DESCRIPTION
(As requested by @gabor-boros at https://github.com/rethinkdb/rethinkdb/pull/6843#issuecomment-609691133 moving the patch here as well.)


**Description**

Hello,

it seems from https://github.com/rethinkdb/rethinkdb/issues/5537 that '-' is allowed in DB and table names. However, the -e option when using rethinkdb-dump breaks when specifying a DB or table with '-' in its name due to this regex.

Opening this pull request to hopefully fix that.