### PR TITLE
Fix not implemented error

### DIFF
--- a/rethinkdb/__init__.py
+++ b/rethinkdb/__init__.py
@@ -11,10 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import imp
-import os
-
-import pkg_resources
 
 from rethinkdb import errors, version
 

--- a/rethinkdb/__init__.py
+++ b/rethinkdb/__init__.py
@@ -61,9 +61,6 @@ class RethinkDB(builtins.object):
         self.set_loop_type(None)
 
     def set_loop_type(self, library=None):
-        if library is None:
-            self.connection_type = self.net.DefaultConnection
-
         if library == "asyncio":
             from rethinkdb.asyncio_net import net_asyncio
             self.connection_type = net_asyncio.Connection
@@ -83,6 +80,9 @@ class RethinkDB(builtins.object):
         if library == "twisted":
             from rethinkdb.twisted_net import net_twisted
             self.connection_type = net_twisted.Connection
+
+        if library is None or self.connection_type is None:
+            self.connection_type = self.net.DefaultConnection
 
         return
 


### PR DESCRIPTION
**Reason for the change**
closes #201 

**Description**
Dynamically importing using the `imp` library causes setuptools and/or pyinstaller to not find the async libraries. 

I also could not get the pyinstaller --hidden-import "rethinkdb.net_asyncio" to work, probably for the same reason.

With these changes the behavior is exactly the same, except now the async libraries are recognised as packages and pyinstaller can create a binary that works.

I appreciate that this change makes the code less dynamic whenever a new async library gets implemented. Maybe there's a better fix? Or maybe pyinstaller will eventually support your way of structuring the rethinkdb package, but this definitely made it work for me.

**Tested with**
- OS: Windows 10
- Python version: 3.8.2

**Checklist**
- [x] I have read and agreed to the [RethinkDB Contributor License Agreement](http://rethinkdb.com/community/cla/)

