### PR TITLE
Fix bug in Trio's `_read_exactly()`

### DIFF
--- a/rethinkdb/trio_net/net_trio.py
+++ b/rethinkdb/trio_net/net_trio.py
@@ -237,8 +237,11 @@ class ConnectionInstance:
         return bytes(buffer)
 
     async def _read_exactly(self, num):
+        data = b''
         try:
-            return await self._stream.receive_some(num)
+            while len(data) < num:
+                data += await self._stream.receive_some(num - len(data))
+            return data
         except (trio.BrokenResourceError, trio.ClosedResourceError):
             self._closed = True
 


### PR DESCRIPTION
**Reason for the change**

The `_read_exactly()` method in the Trio driver sometimes fails on large responses, such as query results that contain lots of data.

**Description**

This method calls Trio's `receive_some(n)`, which I found out can actually
return fewer than `n` bytes. This is only noticeable on large messages
(query results of around 80KB triggered the issue). The solution is to call
`receive_some(...)` in a loop until `n` bytes has been received.

**Code examples**

n/a

**Checklist**

- [X] I have read and agreed to the [RethinkDB Contributor License Agreement](http://rethinkdb.com/community/cla/)

**References**

n/a
