### PR TITLE
Asyncheck

### DIFF
--- a/rethinkdb/ast.py
+++ b/rethinkdb/ast.py
@@ -17,7 +17,6 @@
 
 __all__ = ["expr", "RqlQuery", "ReQLEncoder", "ReQLDecoder", "Repl"]
 
-
 import base64
 import binascii
 import collections
@@ -26,7 +25,8 @@ import json
 import threading
 
 from rethinkdb import ql2_pb2
-from rethinkdb.errors import QueryPrinter, ReqlDriverCompileError, ReqlDriverError, T
+from rethinkdb.errors import (QueryPrinter, ReqlDriverCompileError,
+                              ReqlDriverError, T)
 
 P_TERM = ql2_pb2.Term.TermType
 
@@ -77,7 +77,8 @@ def expr(val, nesting_depth=20):
         Convert a Python primitive into a RQL primitive value
     """
     if not isinstance(nesting_depth, int):
-        raise ReqlDriverCompileError("Second argument to `r.expr` must be a number.")
+        raise ReqlDriverCompileError(
+            "Second argument to `r.expr` must be a number.")
 
     if nesting_depth <= 0:
         raise ReqlDriverCompileError("Nesting depth limit exceeded.")
@@ -95,9 +96,7 @@ def expr(val, nesting_depth=20):
             timezone values with r.make_timezone(\"[+-]HH:MM\"). Alternatively,
             use one of ReQL's bultin time constructors, r.now, r.time,
             or r.iso8601.
-            """
-                % (type(val).__name__)
-            )
+            """ % (type(val).__name__))
         return ISO8601(val.isoformat())
     elif isinstance(val, RqlBinary):
         return Binary(val)
@@ -136,12 +135,10 @@ class RqlQuery(object):
                 if Repl.repl_active:
                     raise ReqlDriverError(
                         "RqlQuery.run must be given a connection to run on. A default connection has been set with "
-                        "`repl()` on another thread, but not this one."
-                    )
+                        "`repl()` on another thread, but not this one.")
                 else:
                     raise ReqlDriverError(
-                        "RqlQuery.run must be given a connection to run on."
-                    )
+                        "RqlQuery.run must be given a connection to run on.")
 
         return c._start(self, **global_optargs)
 
@@ -392,7 +389,10 @@ class RqlQuery(object):
     def __getitem__(self, index):
         if isinstance(index, slice):
             if index.stop:
-                return Slice(self, index.start or 0, index.stop, bracket_operator=True)
+                return Slice(self,
+                             index.start or 0,
+                             index.stop,
+                             bracket_operator=True)
             else:
                 return Slice(
                     self,
@@ -408,8 +408,7 @@ class RqlQuery(object):
         raise ReqlDriverError(
             "__iter__ called on an RqlQuery object.\n"
             "To iterate over the results of a query, call run first.\n"
-            "To iterate inside a query, use map or for_each."
-        )
+            "To iterate inside a query, use map or for_each.")
 
     def get_field(self, *args):
         return GetField(self, *args)
@@ -468,7 +467,7 @@ class RqlQuery(object):
     def map(self, *args):
         if len(args) > 0:
             # `func_wrap` only the last argument
-            return Map(self, *(args[:-1] + (func_wrap(args[-1]),)))
+            return Map(self, *(args[:-1] + (func_wrap(args[-1]), )))
         else:
             return Map(self)
 
@@ -481,7 +480,8 @@ class RqlQuery(object):
             kwfuncargs = {}
             for arg_name in kwargs:
                 kwfuncargs[arg_name] = func_wrap(kwargs[arg_name])
-            return Fold(self, *(args[:-1] + (func_wrap(args[-1]),)), **kwfuncargs)
+            return Fold(self, *(args[:-1] + (func_wrap(args[-1]), )),
+                        **kwfuncargs)
         else:
             return Fold(self)
 
@@ -492,7 +492,10 @@ class RqlQuery(object):
         return ConcatMap(self, *[func_wrap(arg) for arg in args])
 
     def order_by(self, *args, **kwargs):
-        args = [arg if isinstance(arg, (Asc, Desc)) else func_wrap(arg) for arg in args]
+        args = [
+            arg if isinstance(arg, (Asc, Desc)) else func_wrap(arg)
+            for arg in args
+        ]
         return OrderBy(self, *args, **kwargs)
 
     def between(self, *args, **kwargs):
@@ -634,12 +637,14 @@ class RqlBoolOperQuery(RqlQuery):
 
     def compose(self, args, optargs):
         t_args = [
-            T("r.expr(", args[i], ")") if needs_wrap(self._args[i]) else args[i]
+            T("r.expr(", args[i], ")")
+            if needs_wrap(self._args[i]) else args[i]
             for i in xrange(len(args))
         ]
 
         if self.infix:
-            return T("(", T(*t_args, intsp=[" ", self.statement_infix, " "]), ")")
+            return T("(", T(*t_args, intsp=[" ", self.statement_infix, " "]),
+                     ")")
         else:
             return T("r.", self.statement, "(", T(*t_args, intsp=", "), ")")
 
@@ -647,7 +652,8 @@ class RqlBoolOperQuery(RqlQuery):
 class RqlBiOperQuery(RqlQuery):
     def compose(self, args, optargs):
         t_args = [
-            T("r.expr(", args[i], ")") if needs_wrap(self._args[i]) else args[i]
+            T("r.expr(", args[i], ")")
+            if needs_wrap(self._args[i]) else args[i]
             for i in xrange(len(args))
         ]
         return T("(", T(*t_args, intsp=[" ", self.statement, " "]), ")")
@@ -666,11 +672,10 @@ class RqlBiCompareOperQuery(RqlBiOperQuery):
                         "This is almost always a precedence error.\n"
                         "Note that `a < b | b < c` <==> `a < (b | b) < c`.\n"
                         "If you really want this behavior, use `.or_` or "
-                        "`.and_` instead."
-                    )
+                        "`.and_` instead.")
                     raise ReqlDriverCompileError(
-                        err % (self.statement, QueryPrinter(self).print_query())
-                    )
+                        err %
+                        (self.statement, QueryPrinter(self).print_query()))
             except AttributeError:
                 pass  # No infix attribute, so not possible to be an infix bool operator
 
@@ -723,7 +728,7 @@ class RqlTzinfo(datetime.tzinfo):
         self.delta = datetime.timedelta(hours=hours, minutes=minutes)
 
     def __getinitargs__(self):
-        return (self.offsetstr,)
+        return (self.offsetstr, )
 
     def __copy__(self):
         return RqlTzinfo(self.offsetstr)
@@ -751,9 +756,8 @@ def recursively_make_hashable(obj):
     if isinstance(obj, list):
         return tuple([recursively_make_hashable(i) for i in obj])
     elif isinstance(obj, dict):
-        return frozenset(
-            [(k, recursively_make_hashable(v)) for k, v in dict_items(obj)]
-        )
+        return frozenset([(k, recursively_make_hashable(v))
+                          for k, v in dict_items(obj)])
     return obj
 
 
@@ -789,17 +793,12 @@ class ReQLDecoder(json.JSONDecoder):
     def convert_time(self, obj):
         if "epoch_time" not in obj:
             raise ReqlDriverError(
-                (
-                    "pseudo-type TIME object %s does not "
-                    + 'have expected field "epoch_time".'
-                )
-                % json.dumps(obj)
-            )
+                ("pseudo-type TIME object %s does not " +
+                 'have expected field "epoch_time".') % json.dumps(obj))
 
         if "timezone" in obj:
-            return datetime.datetime.fromtimestamp(
-                obj["epoch_time"], RqlTzinfo(obj["timezone"])
-            )
+            return datetime.datetime.fromtimestamp(obj["epoch_time"],
+                                                   RqlTzinfo(obj["timezone"]))
         else:
             return datetime.datetime.utcfromtimestamp(obj["epoch_time"])
 
@@ -807,24 +806,18 @@ class ReQLDecoder(json.JSONDecoder):
     def convert_grouped_data(obj):
         if "data" not in obj:
             raise ReqlDriverError(
-                (
-                    "pseudo-type GROUPED_DATA object"
-                    + ' %s does not have the expected field "data".'
-                )
-                % json.dumps(obj)
-            )
-        return dict([(recursively_make_hashable(k), v) for k, v in obj["data"]])
+                ("pseudo-type GROUPED_DATA object" +
+                 ' %s does not have the expected field "data".') %
+                json.dumps(obj))
+        return dict([(recursively_make_hashable(k), v)
+                     for k, v in obj["data"]])
 
     @staticmethod
     def convert_binary(obj):
         if "data" not in obj:
             raise ReqlDriverError(
-                (
-                    "pseudo-type BINARY object %s does not have "
-                    + 'the expected field "data".'
-                )
-                % json.dumps(obj)
-            )
+                ("pseudo-type BINARY object %s does not have " +
+                 'the expected field "data".') % json.dumps(obj))
         return RqlBinary(base64.b64decode(obj["data"].encode("utf-8")))
 
     def convert_pseudotype(self, obj):
@@ -837,16 +830,14 @@ class ReQLDecoder(json.JSONDecoder):
                     return self.convert_time(obj)
                 elif time_format != "raw":
                     raise ReqlDriverError(
-                        'Unknown time_format run option "%s".' % time_format
-                    )
+                        'Unknown time_format run option "%s".' % time_format)
             elif reql_type == "GROUPED_DATA":
                 group_format = self.reql_format_opts.get("group_format")
                 if group_format is None or group_format == "native":
                     return self.convert_grouped_data(obj)
                 elif group_format != "raw":
                     raise ReqlDriverError(
-                        'Unknown group_format run option "%s".' % group_format
-                    )
+                        'Unknown group_format run option "%s".' % group_format)
             elif reql_type == "GEOMETRY":
                 # No special support for this. Just return the raw object
                 return obj
@@ -856,8 +847,8 @@ class ReQLDecoder(json.JSONDecoder):
                     return self.convert_binary(obj)
                 elif binary_format != "raw":
                     raise ReqlDriverError(
-                        'Unknown binary_format run option "%s".' % binary_format
-                    )
+                        'Unknown binary_format run option "%s".' %
+                        binary_format)
             else:
                 raise ReqlDriverError("Unknown pseudo-type %s" % reql_type)
         # If there was no pseudotype, or the relevant format is raw, return
@@ -911,10 +902,10 @@ class MakeObj(RqlQuery):
     def compose(self, args, optargs):
         return T(
             "r.expr({",
-            T(
-                *[T(repr(key), ": ", value) for key, value in dict_items(optargs)],
-                intsp=", "
-            ),
+            T(*[
+                T(repr(key), ": ", value) for key, value in dict_items(optargs)
+            ],
+                intsp=", "),
             "})",
         )
 
@@ -1236,13 +1227,16 @@ class FunCall(RqlQuery):
     # before passing it down to the base class constructor.
     def __init__(self, *args):
         if len(args) == 0:
-            raise ReqlDriverCompileError("Expected 1 or more arguments but found 0.")
+            raise ReqlDriverCompileError(
+                "Expected 1 or more arguments but found 0.")
         args = [func_wrap(args[-1])] + list(args[:-1])
         RqlQuery.__init__(self, *args)
 
     def compose(self, args, optargs):
         if len(args) != 2:
-            return T("r.do(", T(T(*(args[1:]), intsp=", "), args[0], intsp=", "), ")")
+            return T("r.do(", T(T(*(args[1:]), intsp=", "),
+                                args[0],
+                                intsp=", "), ")")
 
         if isinstance(self._args[1], Datum):
             args[1] = T("r.expr(", args[1], ")")
@@ -1712,12 +1706,10 @@ class RqlBinary(bytes):
 
     def __repr__(self):
         excerpt = binascii.hexlify(self[0:6]).decode("utf-8")
-        excerpt = " ".join([excerpt[i : i + 2] for i in xrange(0, len(excerpt), 2)])
-        excerpt = (
-            ", '%s%s'" % (excerpt, "..." if len(self) > 6 else "")
-            if len(self) > 0
-            else ""
-        )
+        excerpt = " ".join(
+            [excerpt[i:i + 2] for i in xrange(0, len(excerpt), 2)])
+        excerpt = (", '%s%s'" % (excerpt, "..." if len(self) > 6 else "")
+                   if len(self) > 0 else "")
         return "<binary, %d byte%s%s>" % (
             len(self),
             "s" if len(self) != 1 else "",
@@ -1741,16 +1733,11 @@ class Binary(RqlTopLevelQuery):
             raise ReqlDriverCompileError(
                 "Cannot convert a unicode string to binary, "
                 "use `unicode.encode()` to specify the "
-                "encoding."
-            )
+                "encoding.")
         elif not isinstance(data, bytes):
             raise ReqlDriverCompileError(
-                (
-                    "Cannot convert %s to binary, convert the "
-                    "object to a `bytes` object first."
-                )
-                % type(data).__name__
-            )
+                ("Cannot convert %s to binary, convert the "
+                 "object to a `bytes` object first.") % type(data).__name__)
         else:
             self.base64_data = base64.b64encode(data)
 
@@ -1766,7 +1753,10 @@ class Binary(RqlTopLevelQuery):
 
     def build(self):
         if len(self._args) == 0:
-            return {"$reql_type$": "BINARY", "data": self.base64_data.decode("utf-8")}
+            return {
+                "$reql_type$": "BINARY",
+                "data": self.base64_data.decode("utf-8")
+            }
         else:
             return RqlTopLevelQuery.build(self)
 
@@ -1974,10 +1964,11 @@ class Func(RqlQuery):
     def compose(self, args, optargs):
         return T(
             "lambda ",
-            T(
-                *[v.compose([v._args[0].compose(None, None)], []) for v in self.vrs],
-                intsp=", "
-            ),
+            T(*[
+                v.compose([v._args[0].compose(None, None)], [])
+                for v in self.vrs
+            ],
+                intsp=", "),
             ": ",
             args[1],
         )

--- a/rethinkdb/asyncio_net/net_asyncio.py
+++ b/rethinkdb/asyncio_net/net_asyncio.py
@@ -31,28 +31,25 @@ from rethinkdb.errors import (
 )
 from rethinkdb.net import Connection as ConnectionBase
 from rethinkdb.net import Cursor, Query, Response, maybe_profile
+from tasktools.taskloop import TaskLoop
+from networktools.colorprint import gprint, bprint, rprint
 
 __all__ = ["Connection"]
-
 
 pResponse = ql2_pb2.Response.ResponseType
 pQuery = ql2_pb2.Query.QueryType
 
 
-@asyncio.coroutine
-def _read_until(streamreader, delimiter):
+async def _read_until(streamreader, delimiter):
     """Naive implementation of reading until a delimiter"""
-    buffer = bytearray()
-
-    while True:
-        c = yield from streamreader.read(1)
-        if c == b"":
-            break  # EOF
-        buffer.append(c[0])
-        if c == delimiter:
-            break
-
-    return bytes(buffer)
+    try:
+        result = await streamreader.readuntil(delimiter)
+        return bytes(result)
+    except asyncio.IncompleteReadError as ie:
+        return bytes(b"")
+    except asyncio.LimitOverrunError as lo:
+        print("Amount of data exceeds the configured stream limit")
+        raise lo
 
 
 def reusable_waiter(loop, timeout):
@@ -62,20 +59,20 @@ def reusable_waiter(loop, timeout):
 
         waiter = reusable_waiter(event_loop, 10.0)
         while some_condition:
-            yield from waiter(some_future)
+            await waiter(some_future)
     """
     if timeout is not None:
         deadline = loop.time() + timeout
     else:
         deadline = None
 
-    @asyncio.coroutine
-    def wait(future):
+    async def wait(future):
         if deadline is not None:
             new_timeout = max(deadline - loop.time(), 0)
         else:
             new_timeout = None
-        return (yield from asyncio.wait_for(future, new_timeout, loop=loop))
+        # loop parameter deprecated on py3.8
+        return (await asyncio.wait_for(future, new_timeout))
 
     return wait
 
@@ -101,20 +98,18 @@ class AsyncioCursor(Cursor):
     def __aiter__(self):
         return self
 
-    @asyncio.coroutine
-    def __anext__(self):
+    async def __anext__(self):
         try:
-            return (yield from self._get_next(None))
+            return (await self._get_next(None))
         except ReqlCursorEmpty:
             raise StopAsyncIteration
 
-    @asyncio.coroutine
-    def close(self):
+    async def close(self):
         if self.error is None:
             self.error = self._empty_error()
             if self.conn.is_open():
                 self.outstanding_requests += 1
-                yield from self.conn._parent._stop(self)
+                await self.conn._parent._stop(self)
 
     def _extend(self, res_buf):
         Cursor._extend(self, res_buf)
@@ -123,8 +118,7 @@ class AsyncioCursor(Cursor):
 
     # Convenience function so users know when they've hit the end of the cursor
     # without having to catch an exception
-    @asyncio.coroutine
-    def fetch_next(self, wait=True):
+    async def fetch_next(self, wait=True):
         timeout = Cursor._wait_to_timeout(wait)
         waiter = reusable_waiter(self.conn._io_loop, timeout)
         while len(self.items) == 0 and self.error is None:
@@ -132,33 +126,30 @@ class AsyncioCursor(Cursor):
             if self.error is not None:
                 raise self.error
             with translate_timeout_errors():
-                yield from waiter(asyncio.shield(self.new_response))
+                await waiter(asyncio.shield(self.new_response))
         # If there is a (non-empty) error to be received, we return True, so the
         # user will receive it on the next `next` call.
-        return len(self.items) != 0 or not isinstance(self.error, RqlCursorEmpty)
+        return len(self.items) != 0 or not isinstance(self.error,
+                                                      RqlCursorEmpty)
 
     def _empty_error(self):
         # We do not have RqlCursorEmpty inherit from StopIteration as that interferes
         # with mechanisms to return from a coroutine.
         return RqlCursorEmpty()
 
-    @asyncio.coroutine
-    def _get_next(self, timeout):
+    async def _get_next(self, timeout):
         waiter = reusable_waiter(self.conn._io_loop, timeout)
         while len(self.items) == 0:
             self._maybe_fetch_batch()
             if self.error is not None:
                 raise self.error
             with translate_timeout_errors():
-                yield from waiter(asyncio.shield(self.new_response))
+                await waiter(asyncio.shield(self.new_response))
         return self.items.popleft()
 
     def _maybe_fetch_batch(self):
-        if (
-            self.error is None
-            and len(self.items) < self.threshold
-            and self.outstanding_requests == 0
-        ):
+        if (self.error is None and len(self.items) < self.threshold
+                and self.outstanding_requests == 0):
             self.outstanding_requests += 1
             asyncio.ensure_future(self.conn._parent._continue(self))
 
@@ -177,6 +168,15 @@ class ConnectionInstance(object):
         self._io_loop = io_loop
         if self._io_loop is None:
             self._io_loop = asyncio.get_event_loop()
+        asyncio.set_event_loop(self._io_loop)
+
+    @property
+    def writer(self):
+        return self._streamwriter
+
+    @property
+    def reader(self):
+        return self._streamreader
 
     def client_port(self):
         if self.is_open():
@@ -186,8 +186,11 @@ class ConnectionInstance(object):
         if self.is_open():
             return self._streamwriter.get_extra_info("sockname")[0]
 
-    @asyncio.coroutine
-    def connect(self, timeout):
+    async def read_task(self):
+        task = TaskLoop(self._reader, [], {}, name='reader_rdb')
+        task.create()
+
+    async def connect(self, timeout):
         try:
             ssl_context = None
             if len(self._parent.ssl) > 0:
@@ -199,23 +202,20 @@ class ConnectionInstance(object):
                 ssl_context.check_hostname = True  # redundant with match_hostname
                 ssl_context.load_verify_locations(self._parent.ssl["ca_certs"])
 
-            self._streamreader, self._streamwriter = yield from asyncio.open_connection(
+            self._streamreader, self._streamwriter = await asyncio.open_connection(
                 self._parent.host,
                 self._parent.port,
                 loop=self._io_loop,
                 ssl=ssl_context,
             )
             self._streamwriter.get_extra_info("socket").setsockopt(
-                socket.IPPROTO_TCP, socket.TCP_NODELAY, 1
-            )
+                socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
             self._streamwriter.get_extra_info("socket").setsockopt(
-                socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1
-            )
+                socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)
         except Exception as err:
             raise ReqlDriverError(
-                "Could not connect to %s:%s. Error: %s"
-                % (self._parent.host, self._parent.port, str(err))
-            )
+                "Could not connect to %s:%s. Error: %s" %
+                (self._parent.host, self._parent.port, str(err)))
 
         try:
             self._parent.handshake.reset()
@@ -227,41 +227,39 @@ class ConnectionInstance(object):
                         break
                     # This may happen in the `V1_0` protocol where we send two requests as
                     # an optimization, then need to read each separately
-                    if request is not "":
+                    if request != "":
                         self._streamwriter.write(request)
 
-                    response = yield from asyncio.wait_for(
-                        _read_until(self._streamreader, b"\0"),
-                        timeout,
-                        loop=self._io_loop,
-                    )
+                    response = await asyncio.wait_for(
+                        _read_until(self._streamreader, b"\0"), timeout)
                     response = response[:-1]
         except ReqlAuthError:
-            yield from self.close()
+            await self.close()
             raise
         except ReqlTimeoutError as err:
-            yield from self.close()
+            await self.close()
             raise ReqlDriverError(
                 "Connection interrupted during handshake with %s:%s. Error: %s"
-                % (self._parent.host, self._parent.port, str(err))
-            )
+                % (self._parent.host, self._parent.port, str(err)))
         except Exception as err:
-            yield from self.close()
+            await self.close()
             raise ReqlDriverError(
-                "Could not connect to %s:%s. Error: %s"
-                % (self._parent.host, self._parent.port, str(err))
-            )
+                "Could not connect to %s:%s. Error: %s" %
+                (self._parent.host, self._parent.port, str(err)))
 
         # Start a parallel function to perform reads
         #  store a reference to it so it doesn't get destroyed
-        self._reader_task = asyncio.ensure_future(self._reader(), loop=self._io_loop)
+
+        self._reader_task = asyncio.run_coroutine_threadsafe(
+            self.read_task(), self._io_loop)
+        # self._reader_task = asyncio.ensure_future(self._reader(),
+        #                                          loop=self._io_loop)
         return self._parent
 
     def is_open(self):
         return not (self._closing or self._streamreader.at_eof())
 
-    @asyncio.coroutine
-    def close(self, noreply_wait=False, token=None, exception=None):
+    async def close(self, noreply_wait=False, token=None, exception=None):
         self._closing = True
         if exception is not None:
             err_message = "Connection is closed (%s)." % str(exception)
@@ -281,67 +279,79 @@ class ConnectionInstance(object):
 
         if noreply_wait:
             noreply = Query(pQuery.NOREPLY_WAIT, token, None, None)
-            yield from self.run_query(noreply, False)
+            await self.run_query(noreply, False)
 
         self._streamwriter.close()
+        await self._streamwriter.wait_closed()
         # We must not wait for the _reader_task if we got an exception, because that
         # means that we were called from it. Waiting would lead to a deadlock.
         if self._reader_task and exception is None:
-            yield from self._reader_task
+            await self._reader_task
 
         return None
 
-    @asyncio.coroutine
-    def run_query(self, query, noreply):
-        self._streamwriter.write(query.serialize(self._parent._get_json_encoder(query)))
+    async def run_query(self, query, noreply):
+        serialized_query = query.serialize(
+            self._parent._get_json_encoder(query))
+        gprint("_" * 30)
+        bprint(f"query {serialized_query}")
+        gprint("_" * 30)
+        self._streamwriter.write(serialized_query)
+        await self._streamwriter.drain()
         if noreply:
             return None
-
-        response_future = asyncio.Future()
+        response_future = self._io_loop.create_future()
         self._user_queries[query.token] = (query, response_future)
-        return (yield from response_future)
+        result = await response_future
+        return result
 
     # The _reader coroutine runs in parallel, reading responses
     # off of the socket and forwarding them to the appropriate Future or Cursor.
     # This is shut down as a consequence of closing the stream, or an error in the
     # socket/protocol from the server.  Unexpected errors in this coroutine will
     # close the ConnectionInstance and be passed to any open Futures or Cursors.
-    @asyncio.coroutine
-    def _reader(self):
+    async def _reader(self, *args, **kwargs):
+        # now the loop is on the taskloop
         try:
-            while True:
-                buf = yield from self._streamreader.readexactly(12)
-                (token, length,) = struct.unpack("<qL", buf)
-                buf = yield from self._streamreader.readexactly(length)
+            nbytes = 12
+            buf = b""
+            buf = await self._streamreader.readexactly(nbytes)
+            (
+                token,
+                length,
+            ) = struct.unpack("<qL", buf)
+            buf = await self._streamreader.readexactly(length)
 
-                cursor = self._cursor_cache.get(token)
-                if cursor is not None:
-                    cursor._extend(buf)
-                elif token in self._user_queries:
-                    # Do not pop the query from the dict until later, so
-                    # we don't lose track of it in case of an exception
-                    query, future = self._user_queries[token]
-                    res = Response(token, buf, self._parent._get_json_decoder(query))
-                    if res.type == pResponse.SUCCESS_ATOM:
-                        future.set_result(maybe_profile(res.data[0], res))
-                    elif res.type in (
+            cursor = self._cursor_cache.get(token)
+            if cursor is not None:
+                cursor._extend(buf)
+            elif token in self._user_queries:
+                # Do not pop the query from the dict until later, so
+                # we don't lose track of it in case of an exception
+                query, future = self._user_queries[token]
+                res = Response(token, buf,
+                               self._parent._get_json_decoder(query))
+                if res.type == pResponse.SUCCESS_ATOM:
+                    future.set_result(maybe_profile(res.data[0], res))
+                elif res.type in (
                         pResponse.SUCCESS_SEQUENCE,
                         pResponse.SUCCESS_PARTIAL,
-                    ):
-                        cursor = AsyncioCursor(self, query, res)
-                        future.set_result(maybe_profile(cursor, res))
-                    elif res.type == pResponse.WAIT_COMPLETE:
-                        future.set_result(None)
-                    elif res.type == pResponse.SERVER_INFO:
-                        future.set_result(res.data[0])
-                    else:
-                        future.set_exception(res.make_error(query))
-                    del self._user_queries[token]
-                elif not self._closing:
-                    raise ReqlDriverError("Unexpected response received.")
+                ):
+                    cursor = AsyncioCursor(self, query, res)
+                    future.set_result(maybe_profile(cursor, res))
+                elif res.type == pResponse.WAIT_COMPLETE:
+                    future.set_result(None)
+                elif res.type == pResponse.SERVER_INFO:
+                    future.set_result(res.data[0])
+                else:
+                    future.set_exception(res.make_error(query))
+                del self._user_queries[token]
+            elif not self._closing:
+                raise ReqlDriverError("Unexpected response received.")
         except Exception as ex:
             if not self._closing:
-                yield from self.close(exception=ex)
+                await self.close(exception=ex)
+        return args, kwargs
 
 
 class Connection(ConnectionBase):
@@ -350,34 +360,28 @@ class Connection(ConnectionBase):
         try:
             self.port = int(self.port)
         except ValueError:
-            raise ReqlDriverError(
-                "Could not convert port %s to an integer." % self.port
-            )
+            raise ReqlDriverError("Could not convert port %s to an integer." %
+                                  self.port)
 
-    @asyncio.coroutine
-    def __aenter__(self):
+    async def __aenter__(self):
         return self
 
-    @asyncio.coroutine
-    def __aexit__(self, exception_type, exception_val, traceback):
-        yield from self.close(False)
+    async def __aexit__(self, exception_type, exception_val, traceback):
+        await self.close(False)
 
-    @asyncio.coroutine
-    def _stop(self, cursor):
+    async def _stop(self, cursor):
         self.check_open()
         q = Query(pQuery.STOP, cursor.query.token, None, None)
-        return (yield from self._instance.run_query(q, True))
+        return (await self._instance.run_query(q, True))
 
-    @asyncio.coroutine
-    def reconnect(self, noreply_wait=True, timeout=None):
+    async def reconnect(self, noreply_wait=True, timeout=None):
         # We close before reconnect so reconnect doesn't try to close us
         # and then fail to return the Future (this is a little awkward).
-        yield from self.close(noreply_wait)
+        await self.close(noreply_wait)
         self._instance = self._conn_type(self, **self._child_kwargs)
-        return (yield from self._instance.connect(timeout))
+        return (await self._instance.connect(timeout))
 
-    @asyncio.coroutine
-    def close(self, noreply_wait=True):
+    async def close(self, noreply_wait=True):
         if self._instance is None:
             return None
-        return (yield from ConnectionBase.close(self, noreply_wait=noreply_wait))
+        return (await self._instance.close())

--- a/rethinkdb/asyncio_net/net_asyncio.py
+++ b/rethinkdb/asyncio_net/net_asyncio.py
@@ -32,7 +32,6 @@ from rethinkdb.errors import (
 from rethinkdb.net import Connection as ConnectionBase
 from rethinkdb.net import Cursor, Query, Response, maybe_profile
 from tasktools.taskloop import TaskLoop
-from networktools.colorprint import gprint, bprint, rprint
 
 __all__ = ["Connection"]
 
@@ -293,9 +292,6 @@ class ConnectionInstance(object):
     async def run_query(self, query, noreply):
         serialized_query = query.serialize(
             self._parent._get_json_encoder(query))
-        gprint("_" * 30)
-        bprint(f"query {serialized_query}")
-        gprint("_" * 30)
         self._streamwriter.write(serialized_query)
         await self._streamwriter.drain()
         if noreply:


### PR DESCRIPTION
**Reason for the change**
The new versions of Python3 require use 'drain' after write. Some syntaxis corrections. Some better algorithms.

**Description**
Dropped the 'loop' parameter where is deprecated. After write, use 'drain'. A reader in an async loop. Use async/await pair. The modern statements
Some better asyncio exception (have some more to consider)

**Code examples**
On documentation:
https://docs.python.org/3/library/asyncio-stream.html#asyncio.StreamWriter

Uses on the tests scripts:
https://gitlab.com/pineiden/datadbs-rethinkdb/-/tree/master/tests

Save data:
- load data on table: load_data.py
Read data:
read_data.py
simple_loop_*.py scripts
simple_test_*,py script

Interact with rdb:
crea_perfiles.py

**Checklist**
- [x ] I have read and agreed to the [RethinkDB Contributor License Agreement](http://rethinkdb.com/community/cla/)

**References**

https://docs.python.org/3/library/asyncio-stream.html#asyncio.StreamWriter

Using TaskLoop:
https://tasktools.readthedocs.io/en/latest/
Example:
https://gitlab.com/pineiden/tasktools/-/tree/master/test

Anything else related to the change e.g. documentations, RFCs, etc.
