### PR TITLE
Update net_asyncio.py

### DIFF
--- a/rethinkdb/asyncio_net/net_asyncio.py
+++ b/rethinkdb/asyncio_net/net_asyncio.py
@@ -69,7 +69,6 @@ def reusable_waiter(loop, timeout):
     else:
         deadline = None
 
-    @asyncio.coroutine
     def wait(future):
         if deadline is not None:
             new_timeout = max(deadline - loop.time(), 0)
@@ -284,6 +283,7 @@ class ConnectionInstance(object):
             yield from self.run_query(noreply, False)
 
         self._streamwriter.close()
+        await self._streamwriter.wait_closed()
         # We must not wait for the _reader_task if we got an exception, because that
         # means that we were called from it. Waiting would lead to a deadlock.
         if self._reader_task and exception is None:


### PR DESCRIPTION
**Reason for the change**
If applicable, link the related issue/bug report or write down in few sentences the motivation.

**Description**
A clear and concise description of what did you changed and why.

**Code examples**
If applicable, add code examples to help explain your changes.

**Checklist**
- [ ] I have read and agreed to the [RethinkDB Contributor License Agreement](http://rethinkdb.com/community/cla/)

**References**
Anything else related to the change e.g. documentations, RFCs, etc.


At the python doc, a closing of async socket has that two lines:


```            
self.streamwriter.close()
await self.streamwriter.wait_closed()
```

In my case, despite closing connections, those are not closing and the number of open cons are increasing (without second line)






