### PR TITLE
fix failing dump command

### DIFF
--- a/rethinkdb/utils_common.py
+++ b/rethinkdb/utils_common.py
@@ -308,7 +308,7 @@ class CommonOptionsParser(optparse.OptionParser, object):
 
                     values.ensure_value(dest, {})[self.metavar.lower()] = value
                 elif action == "get_password":
-                    values[dest] = getpass.getpass("Password for `admin`: ")
+                    values.ensure_value('password', getpass.getpass("Password for `admin`: "))
                 else:
                     super(CommonOptionChecker, self).take_action(
                         action, dest, opt, value, values, parser


### PR DESCRIPTION
**Reason for the change**

Per Issue https://github.com/rethinkdb/rethinkdb-python/issues/225

```
File ".../rethinkdb/utils_common.py", line 311, in take_action
values[dest] = getpass.getpass("Password for admin: ")
TypeError: 'Values' object does not support item assignment
```

**Description**
The `values` object is an instance of [`optparse_parser.Values`](https://docs.python.org/3/library/optparse.html) which, as the error message states, does not support item assignment. I modified the option checker to use the `ensure_value` method of the values object to set the password.

**Checklist**
- [x] I have read and agreed to the [RethinkDB Contributor License Agreement](http://rethinkdb.com/community/cla/)