### PR TITLE
feat: add command base

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -3,3 +3,5 @@ ignore=E203,E501,W503
 max-line-length=88
 application_import_names=rethinkdb
 exclude = .git,__pycache__,tests
+per-file-ignores =
+     rethinkdb/cli/__init__.py: F401

--- a/poetry.lock
+++ b/poetry.lock
@@ -118,7 +118,7 @@ unicode_backport = ["unicodedata2"]
 name = "click"
 version = "8.1.3"
 description = "Composable command line interface toolkit"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.7"
 
@@ -130,7 +130,7 @@ importlib-metadata = {version = "*", markers = "python_version < \"3.8\""}
 name = "colorama"
 version = "0.4.5"
 description = "Cross-platform colored terminal text."
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
@@ -261,7 +261,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 name = "importlib-metadata"
 version = "4.2.0"
 description = "Read metadata from Python packages"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.6"
 
@@ -759,7 +759,7 @@ python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
 name = "zipp"
 version = "3.8.0"
 description = "Backport of pathlib-compatible object wrapper for zip files"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.7"
 
@@ -773,7 +773,7 @@ all = []
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "1188177f9b4a69cea9a4091b4eae8da377cf07890872f8f04fb231af2acc56cb"
+content-hash = "9a1c1bdc6cd3b9d421d1cb138c4776b6b7d8fc3ff7fd007a19be6cbd8b9f9cf2"
 
 [metadata.files]
 alabaster = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,14 +36,22 @@ maintainers = [
 [tool.poetry.urls]
 "Bug Tracker" = "https://github.com/rethinkdb/rethinkdb-python/issues/"
 
-# this should be shipped with the C++ code not the python client
-# [tool.poetry.scripts]
-# rethinkdb-import = 'rethinkdb.main:app'
+# RethinkDB is aliasing the commands to `rethinkdb <command>`, therefore it
+# can be executed as `rethinkdb dump` or `rethinkdb-dump`.
+[tool.poetry.scripts]
+rethinkdb = "rethinkdb.cli.main:cmd_main"
+rethinkdb-dump = "rethinkdb.cli._dump:cmd_dump"
+rethinkdb-export = "rethinkdb.cli._export:cmd_export"
+rethinkdb-import = "rethinkdb.cli._import:cmd_import"
+rethinkdb-index-rebuild = "rethinkdb.cli._index_rebuild:cmd_index_rebuild"
+rethinkdb-repl = "rethinkdb.cli._repl:cmd_repl"
+rethinkdb-restore = "rethinkdb.cli._restore:cmd_restore"
 
 [tool.poetry.dependencies]
 pydantic = "^1.9"
 python = "^3.7"
 ujson = "^5.2.0"
+click = "^8.1.3"
 
 [tool.poetry.dev-dependencies]
 bandit = "^1.7"

--- a/rethinkdb/cli/__init__.py
+++ b/rethinkdb/cli/__init__.py
@@ -1,0 +1,28 @@
+# Copyright 2022 RethinkDB
+#
+# Licensed under the Apache License, Version 2.0 (the 'License');
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an 'AS IS' BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+RethinkDB CLI module defines the management commands that can be used to
+interact with the database. These commands are for exporting/importing data.
+
+Although these commands can be used to prepare data for backup, depending on
+your needs, you may want to evaluate more mature backup backup solutions.
+"""
+
+from rethinkdb.cli._dump import cmd_dump
+from rethinkdb.cli._export import cmd_export
+from rethinkdb.cli._import import cmd_import
+from rethinkdb.cli._index_rebuild import cmd_index_rebuild
+from rethinkdb.cli._repl import cmd_repl
+from rethinkdb.cli._restore import cmd_restore

--- a/rethinkdb/cli/_dump.py
+++ b/rethinkdb/cli/_dump.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python
+
+# Copyright 2022 RethinkDB
+#
+# Licensed under the Apache License, Version 2.0 (the 'License');
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an 'AS IS' BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# This file incorporates work covered by the following copyright:
+# Copyright 2010-2016 RethinkDB, all rights reserved.
+
+"""
+Dump creates an archive of data from a RethinkDB cluster.
+"""
+import click
+
+
+@click.command
+def cmd_dump():
+    """
+    Dump creates an archive of data from a RethinkDB cluster.
+    """
+    click.echo("dump command")

--- a/rethinkdb/cli/_export.py
+++ b/rethinkdb/cli/_export.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python
+
+# Copyright 2022 RethinkDB
+#
+# Licensed under the Apache License, Version 2.0 (the 'License');
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an 'AS IS' BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# This file incorporates work covered by the following copyright:
+# Copyright 2010-2016 RethinkDB, all rights reserved.
+
+"""
+Export exports data from a RethinkDB cluster into a directory.
+"""
+import click
+
+
+@click.command
+def cmd_export():
+    """
+    Export data from a RethinkDB cluster into a directory.
+    """
+    click.echo("export command")

--- a/rethinkdb/cli/_import.py
+++ b/rethinkdb/cli/_import.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python
+
+# Copyright 2022 RethinkDB
+#
+# Licensed under the Apache License, Version 2.0 (the 'License');
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an 'AS IS' BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# This file incorporates work covered by the following copyright:
+# Copyright 2010-2016 RethinkDB, all rights reserved.
+
+"""
+Import loads data into a RethinkDB cluster.
+"""
+
+import click
+
+
+@click.command
+def cmd_import():
+    """
+    Import loads data into a RethinkDB cluster.
+    """
+    click.echo("import command")

--- a/rethinkdb/cli/_index_rebuild.py
+++ b/rethinkdb/cli/_index_rebuild.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python
+
+# Copyright 2022 RethinkDB
+#
+# Licensed under the Apache License, Version 2.0 (the 'License');
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an 'AS IS' BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# This file incorporates work covered by the following copyright:
+# Copyright 2010-2016 RethinkDB, all rights reserved.
+
+"""
+Index rebuild recreates outdated secondary indexes in a cluster.
+
+This should be used after upgrading to a newer version of rethinkdb. There
+will be a notification in the web UI if any secondary indexes are out-of-date.
+"""
+
+import click
+
+
+@click.command
+def cmd_index_rebuild():
+    """
+    Rebuild outdated secondary indexes.
+    """
+    click.echo("index rebuild command")

--- a/rethinkdb/cli/_repl.py
+++ b/rethinkdb/cli/_repl.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python
+
+# Copyright 2022 RethinkDB
+#
+# Licensed under the Apache License, Version 2.0 (the 'License');
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an 'AS IS' BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# This file incorporates work covered by the following copyright:
+# Copyright 2010-2016 RethinkDB, all rights reserved.
+
+"""
+The main command is a special group that is the root of the command tree.
+
+This command creates a subcommand tree that with the following commands for
+those cases when the rethinkdb binary is not installed:
+    - dump
+    - export
+    - import
+    - index_rebuild
+    - repl
+    - restore
+"""
+
+import click
+
+
+@click.command
+def cmd_repl():
+    """
+    Rebuild outdated secondary indexes.
+    """
+    click.echo("repl command")

--- a/rethinkdb/cli/_restore.py
+++ b/rethinkdb/cli/_restore.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python
+
+# Copyright 2022 RethinkDB
+#
+# Licensed under the Apache License, Version 2.0 (the 'License');
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an 'AS IS' BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# This file incorporates work covered by the following copyright:
+# Copyright 2010-2016 RethinkDB, all rights reserved.
+
+"""
+Restore loads data into a RethinkDB cluster from an archive.
+"""
+
+import click
+
+
+@click.command
+def cmd_restore():
+    """
+    Restore loads data into a RethinkDB cluster from an archive.
+    """
+    click.echo("restore command")

--- a/rethinkdb/cli/main.py
+++ b/rethinkdb/cli/main.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python
+
+# Copyright 2022 RethinkDB
+#
+# Licensed under the Apache License, Version 2.0 (the 'License');
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an 'AS IS' BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# This file incorporates work covered by the following copyright:
+# Copyright 2010-2016 RethinkDB, all rights reserved.
+
+"""
+The main command is a special group that is the root of the command tree.
+
+This command creates a subcommand tree that with the following commands for
+those cases when the rethinkdb binary is not installed:
+    - dump
+    - export
+    - import
+    - index_rebuild
+    - repl
+    - restore
+"""
+
+import click
+
+from rethinkdb.cli import (
+    cmd_dump,
+    cmd_export,
+    cmd_import,
+    cmd_index_rebuild,
+    cmd_repl,
+    cmd_restore,
+)
+
+
+@click.group
+def cmd_main():
+    """
+    Group of commands for the RethinkDB database.
+    """
+
+
+cmd_main.add_command(cmd_dump, "dump")
+cmd_main.add_command(cmd_export, "export")
+cmd_main.add_command(cmd_import, "import")
+cmd_main.add_command(cmd_index_rebuild, "index_rebuild")
+cmd_main.add_command(cmd_repl, "repl")
+cmd_main.add_command(cmd_restore, "restore")


### PR DESCRIPTION
**Reason for the change**

Creating a base for porting management commands of the 2.4.x driver.

**Description**

This PR creates the base and structure for management commands:

- dump
- export
- import
- index_rebuild
- repl
- restore

**Code examples**

```shell
# Calling the dump command
$ rethinkdb-dump
# ... or ...
$ rethinkdb dump

# Calling the export command
$ rethinkdb-export
# ... or ...
$ rethinkdb export

# Calling the import command
$ rethinkdb-import
# ... or ...
$ rethinkdb import

# Calling the index_rebuild command
$ rethinkdb-index_rebuild
# ... or ...
$ rethinkdb index_rebuild

# Calling the repl command
$ rethinkdb-repl
# ... or ...
$ rethinkdb repl

# Calling the restore command
$ rethinkdb-restore
# ... or ...
$ rethinkdb restore
```

**Checklist**
- [x] I have read and agreed to the [RethinkDB Contributor License Agreement](http://rethinkdb.com/community/cla/)

**References**
N/A
