### PR TITLE
feat(wip): prepare to implement commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-# Copyright 2022 RethinkDB
+# Copyright 2022 - present RethinkDB
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/rethinkdb/__init__.py
+++ b/rethinkdb/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2022 RethinkDB
+# Copyright 2022 - present RethinkDB
 #
 # Licensed under the Apache License, Version 2.0 (the 'License');
 # you may not use this file except in compliance with the License.

--- a/rethinkdb/ast.py
+++ b/rethinkdb/ast.py
@@ -1,4 +1,4 @@
-# Copyright 2022 RethinkDB
+# Copyright 2022 - present RethinkDB
 #
 # Licensed under the Apache License, Version 2.0 (the 'License');
 # you may not use this file except in compliance with the License.

--- a/rethinkdb/cli/__init__.py
+++ b/rethinkdb/cli/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2022 RethinkDB
+# Copyright 2022 - present RethinkDB
 #
 # Licensed under the Apache License, Version 2.0 (the 'License');
 # you may not use this file except in compliance with the License.

--- a/rethinkdb/cli/_dump.py
+++ b/rethinkdb/cli/_dump.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-# Copyright 2022 RethinkDB
+# Copyright 2022 - present RethinkDB
 #
 # Licensed under the Apache License, Version 2.0 (the 'License');
 # you may not use this file except in compliance with the License.
@@ -20,11 +20,13 @@
 """
 Dump creates an archive of data from a RethinkDB cluster.
 """
+
 import click
 
 
 @click.command
-def cmd_dump():
+@click.pass_context
+def cmd_dump(ctx):
     """
     Dump creates an archive of data from a RethinkDB cluster.
     """

--- a/rethinkdb/cli/_export.py
+++ b/rethinkdb/cli/_export.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-# Copyright 2022 RethinkDB
+# Copyright 2022 - present RethinkDB
 #
 # Licensed under the Apache License, Version 2.0 (the 'License');
 # you may not use this file except in compliance with the License.
@@ -20,11 +20,13 @@
 """
 Export exports data from a RethinkDB cluster into a directory.
 """
+
 import click
 
 
 @click.command
-def cmd_export():
+@click.pass_context
+def cmd_export(ctx):
     """
     Export data from a RethinkDB cluster into a directory.
     """

--- a/rethinkdb/cli/_import.py
+++ b/rethinkdb/cli/_import.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-# Copyright 2022 RethinkDB
+# Copyright 2022 - present RethinkDB
 #
 # Licensed under the Apache License, Version 2.0 (the 'License');
 # you may not use this file except in compliance with the License.
@@ -25,7 +25,8 @@ import click
 
 
 @click.command
-def cmd_import():
+@click.pass_context
+def cmd_import(ctx):
     """
     Import loads data into a RethinkDB cluster.
     """

--- a/rethinkdb/cli/_index_rebuild.py
+++ b/rethinkdb/cli/_index_rebuild.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-# Copyright 2022 RethinkDB
+# Copyright 2022 - present RethinkDB
 #
 # Licensed under the Apache License, Version 2.0 (the 'License');
 # you may not use this file except in compliance with the License.
@@ -28,7 +28,8 @@ import click
 
 
 @click.command
-def cmd_index_rebuild():
+@click.pass_context
+def cmd_index_rebuild(ctx):
     """
     Rebuild outdated secondary indexes.
     """

--- a/rethinkdb/cli/_repl.py
+++ b/rethinkdb/cli/_repl.py
@@ -38,4 +38,3 @@ def cmd_repl(ctx):
     """
 
     click.echo(f"repl command: {ctx}")
-

--- a/rethinkdb/cli/_repl.py
+++ b/rethinkdb/cli/_repl.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-# Copyright 2022 RethinkDB
+# Copyright 2022 - present RethinkDB
 #
 # Licensed under the Apache License, Version 2.0 (the 'License');
 # you may not use this file except in compliance with the License.
@@ -18,24 +18,24 @@
 # Copyright 2010-2016 RethinkDB, all rights reserved.
 
 """
-The main command is a special group that is the root of the command tree.
-
-This command creates a subcommand tree that with the following commands for
-those cases when the rethinkdb binary is not installed:
-    - dump
-    - export
-    - import
-    - index_rebuild
-    - repl
-    - restore
+Start an interactive Python shell (repl) with the RethinkDB driver imported.
 """
 
 import click
 
+BANNER = """
+The RethinkDB driver has been imported as `r`.
+
+A connection to %s:%d has been established as `conn`
+and can be used by calling `run()` on a query without any arguments.
+"""
 
 @click.command
-def cmd_repl():
+@click.pass_context
+def cmd_repl(ctx):
     """
-    Rebuild outdated secondary indexes.
+    Start an interactive Python shell (repl) with the RethinkDB driver imported.
     """
-    click.echo("repl command")
+
+    click.echo(f"repl command: {ctx}")
+

--- a/rethinkdb/cli/_restore.py
+++ b/rethinkdb/cli/_restore.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-# Copyright 2022 RethinkDB
+# Copyright 2022 - present RethinkDB
 #
 # Licensed under the Apache License, Version 2.0 (the 'License');
 # you may not use this file except in compliance with the License.
@@ -25,7 +25,8 @@ import click
 
 
 @click.command
-def cmd_restore():
+@click.pass_context
+def cmd_restore(ctx):
     """
     Restore loads data into a RethinkDB cluster from an archive.
     """

--- a/rethinkdb/cli/main.py
+++ b/rethinkdb/cli/main.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-# Copyright 2022 RethinkDB
+# Copyright 2022 - present RethinkDB
 #
 # Licensed under the Apache License, Version 2.0 (the 'License');
 # you may not use this file except in compliance with the License.
@@ -43,7 +43,38 @@ from rethinkdb.cli import (
 
 
 @click.group
-def cmd_main():
+@click.option(
+    "--debug",
+    default=False,
+    help="Print debug information.",
+    envvar="RETHINKDB_DEBUG",
+    type=click.BOOL,
+)
+@click.option(
+    "--user",
+    "-u",
+    default="admin",
+    help="The RethinkDB user to connect with.",
+    envvar="RETHINKDB_USER",
+    type=click.STRING,
+)
+@click.option(
+    "--host",
+    "-h",
+    default="localhost",
+    help="The RethinkDB host to connect to.",
+    envvar="RETHINKDB_HOSTNAME",
+    type=click.STRING,
+)
+@click.option(
+    "--port",
+    "-p",
+    default=28015,
+    help="The RethinkDB driver port to connect to.",
+    envvar="RETHINKDB_DRIVER_PORT",
+    type=click.INT,
+)
+def cmd_main(*args, **kwargs):
     """
     Group of commands for the RethinkDB database.
     """
@@ -55,3 +86,6 @@ cmd_main.add_command(cmd_import, "import")
 cmd_main.add_command(cmd_index_rebuild, "index_rebuild")
 cmd_main.add_command(cmd_repl, "repl")
 cmd_main.add_command(cmd_restore, "restore")
+
+if __name__ == "__main__":
+    cmd_main(auto_envvar_prefix="RETHINKDB")

--- a/rethinkdb/encoder.py
+++ b/rethinkdb/encoder.py
@@ -1,4 +1,4 @@
-# Copyright 2022 RethinkDB
+# Copyright 2022 - present RethinkDB
 #
 # Licensed under the Apache License, Version 2.0 (the 'License');
 # you may not use this file except in compliance with the License.

--- a/rethinkdb/errors.py
+++ b/rethinkdb/errors.py
@@ -1,4 +1,4 @@
-# Copyright 2022 RethinkDB
+# Copyright 2022 - present RethinkDB
 #
 # Licensed under the Apache License, Version 2.0 (the 'License');
 # you may not use this file except in compliance with the License.

--- a/rethinkdb/handshake.py
+++ b/rethinkdb/handshake.py
@@ -1,4 +1,4 @@
-# Copyright 2022 RethinkDB
+# Copyright 2022 - present RethinkDB
 #
 # Licensed under the Apache License, Version 2.0 (the 'License');
 # you may not use this file except in compliance with the License.

--- a/rethinkdb/query.py
+++ b/rethinkdb/query.py
@@ -1,4 +1,4 @@
-# Copyright 2022 RethinkDB
+# Copyright 2022 - present RethinkDB
 #
 # Licensed under the Apache License, Version 2.0 (the 'License');
 # you may not use this file except in compliance with the License.

--- a/rethinkdb/repl.py
+++ b/rethinkdb/repl.py
@@ -1,4 +1,4 @@
-# Copyright 2022 RethinkDB
+# Copyright 2022 - present RethinkDB
 #
 # Licensed under the Apache License, Version 2.0 (the 'License');
 # you may not use this file except in compliance with the License.

--- a/rethinkdb/utilities.py
+++ b/rethinkdb/utilities.py
@@ -1,4 +1,4 @@
-# Copyright 2022 RethinkDB
+# Copyright 2022 - present RethinkDB
 #
 # Licensed under the Apache License, Version 2.0 (the 'License');
 # you may not use this file except in compliance with the License.

--- a/scripts/convert_protofile.py
+++ b/scripts/convert_protofile.py
@@ -1,4 +1,4 @@
-# Copyright 2022 RethinkDB
+# Copyright 2022 - present RethinkDB
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use
 # this file except in compliance with the License. You may obtain a copy of the

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2022 RethinkDB
+# Copyright 2022 - present RethinkDB
 #
 # Licensed under the Apache License, Version 2.0 (the 'License');
 # you may not use this file except in compliance with the License.

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,4 +1,4 @@
-# Copyright 2022 RethinkDB
+# Copyright 2022 - present RethinkDB
 #
 # Licensed under the Apache License, Version 2.0 (the 'License');
 # you may not use this file except in compliance with the License.

--- a/tests/integration/test_ast.py
+++ b/tests/integration/test_ast.py
@@ -1,4 +1,4 @@
-# Copyright 2022 RethinkDB
+# Copyright 2022 - present RethinkDB
 #
 # Licensed under the Apache License, Version 2.0 (the 'License');
 # you may not use this file except in compliance with the License.

--- a/tests/integration/test_queries.py
+++ b/tests/integration/test_queries.py
@@ -1,4 +1,4 @@
-# Copyright 2022 RethinkDB
+# Copyright 2022 - present RethinkDB
 #
 # Licensed under the Apache License, Version 2.0 (the 'License');
 # you may not use this file except in compliance with the License.

--- a/tests/integration/test_repl.py
+++ b/tests/integration/test_repl.py
@@ -1,4 +1,4 @@
-# Copyright 2022 RethinkDB
+# Copyright 2022 - present RethinkDB
 #
 # Licensed under the Apache License, Version 2.0 (the 'License');
 # you may not use this file except in compliance with the License.

--- a/tests/test_date_and_time.py
+++ b/tests/test_date_and_time.py
@@ -1,4 +1,4 @@
-# Copyright 2022 RethinkDB
+# Copyright 2022 - present RethinkDB
 #
 # Licensed under the Apache License, Version 2.0 (the 'License');
 # you may not use this file except in compliance with the License.

--- a/tests/test_encoder.py
+++ b/tests/test_encoder.py
@@ -1,4 +1,4 @@
-# Copyright 2022 RethinkDB
+# Copyright 2022 - present RethinkDB
 #
 # Licensed under the Apache License, Version 2.0 (the 'License');
 # you may not use this file except in compliance with the License.

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -1,4 +1,4 @@
-# Copyright 2022 RethinkDB
+# Copyright 2022 - present RethinkDB
 #
 # Licensed under the Apache License, Version 2.0 (the 'License');
 # you may not use this file except in compliance with the License.

--- a/tests/test_handshake.py
+++ b/tests/test_handshake.py
@@ -1,4 +1,4 @@
-# Copyright 2022 RethinkDB
+# Copyright 2022 - present RethinkDB
 #
 # Licensed under the Apache License, Version 2.0 (the 'License');
 # you may not use this file except in compliance with the License.

--- a/tests/test_net.py
+++ b/tests/test_net.py
@@ -1,4 +1,4 @@
-# Copyright 2022 RethinkDB
+# Copyright 2022 - present RethinkDB
 #
 # Licensed under the Apache License, Version 2.0 (the 'License');
 # you may not use this file except in compliance with the License.

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -1,4 +1,4 @@
-# Copyright 2022 RethinkDB
+# Copyright 2022 - present RethinkDB
 #
 # Licensed under the Apache License, Version 2.0 (the 'License');
 # you may not use this file except in compliance with the License.

--- a/tests/test_repl.py
+++ b/tests/test_repl.py
@@ -1,4 +1,4 @@
-# Copyright 2022 RethinkDB
+# Copyright 2022 - present RethinkDB
 #
 # Licensed under the Apache License, Version 2.0 (the 'License');
 # you may not use this file except in compliance with the License.

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -1,4 +1,4 @@
-# Copyright 2022 RethinkDB
+# Copyright 2022 - present RethinkDB
 #
 # Licensed under the Apache License, Version 2.0 (the 'License');
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
**Reason for the change**
The CLI command implementation is missing from the Python 3 rewrite. This PR (and branch) is meant to implement all missing commands.

**Code examples**

N/A

**Checklist**

- [x] I have read and agreed to the [RethinkDB Contributor License Agreement](http://rethinkdb.com/community/cla/)

**References**

More info in the description of https://github.com/rethinkdb/rethinkdb-python/pull/277
