### PR TITLE
CI: Fix the failing end-of-line fixer

### DIFF
--- a/rethinkdb/cli/_repl.py
+++ b/rethinkdb/cli/_repl.py
@@ -38,4 +38,3 @@ def cmd_repl(ctx):
     """
 
     click.echo(f"repl command: {ctx}")
-


### PR DESCRIPTION
**Reason for the change**
If applicable, link the related issue/bug report or write down in a few sentences the motivation.

Automated tests are failing with a ❌ so let's get them ✅ again.

**Description**
A clear and concise description of what you changed and why.

A simple fix to get the CI tests to be green again... The `end-of-line fixer` requires that each text file ends with one and only one blank line.

**Code examples**
If applicable, add code examples to help explain your changes.

**Checklist**
- [x] I have read and agreed to the [RethinkDB Contributor License Agreement](http://rethinkdb.com/community/cla/)

**References**
Anything else related to the change e.g. documentations, RFCs, etc.
