### PR TITLE
pylintrc disable=W0613

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -63,6 +63,7 @@ confidence=
 disable=bad-continuation,
         missing-module-docstring,
         W0511
+        W0613
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option


### PR DESCRIPTION
The next step after #288

**Reason for the change**
If applicable, link the related issue/bug report or write down in few sentences the motivation.

**Description**
A clear and concise description of what did you changed and why.

**Code examples**
If applicable, add code examples to help explain your changes.

**Checklist**
- [x] I have read and agreed to the [RethinkDB Contributor License Agreement](http://rethinkdb.com/community/cla/)

**References**
Anything else related to the change e.g. documentations, RFCs, etc.
```
pylint rethinkdb
************* Module rethinkdb.cli.main
rethinkdb/cli/main.py:77:0: W0613: Unused argument 'args' (unused-argument)
rethinkdb/cli/main.py:77:0: W0613: Unused argument 'kwargs' (unused-argument)
************* Module rethinkdb.cli._index_rebuild
rethinkdb/cli/_index_rebuild.py:32:22: W0613: Unused argument 'ctx' (unused-argument)
************* Module rethinkdb.cli._restore
rethinkdb/cli/_restore.py:29:16: W0613: Unused argument 'ctx' (unused-argument)
************* Module rethinkdb.cli._dump
rethinkdb/cli/_dump.py:29:13: W0613: Unused argument 'ctx' (unused-argument)
************* Module rethinkdb.cli._export
rethinkdb/cli/_export.py:29:15: W0613: Unused argument 'ctx' (unused-argument)
************* Module rethinkdb.cli._import
rethinkdb/cli/_import.py:29:15: W0613: Unused argument 'ctx' (unused-argument)

-----------------------------------
Your code has been rated at 9.97/10

make: *** [Makefile:106: lint] Error 4
Error: Process completed with exit code 2.
```
@lsabi Your review, please.