### PR TITLE
bug: fix query representation to string

### DIFF
--- a/rethinkdb/ast.py
+++ b/rethinkdb/ast.py
@@ -647,7 +647,7 @@ class RqlBoolOperQuery(RqlQuery):
         ]
 
         if self.infix:
-            return T("(", T(*t_args, intsp=[" ", self.statement_infix, " "]), ")")
+            return T("(", T(*t_args, intsp=[" ", self.st_infix, " "]), ")")
         else:
             return T("r.", self.statement, "(", T(*t_args, intsp=", "), ")")
 


### PR DESCRIPTION
**Reason for the change**
If applicable, link the related issue/bug report or write down in few sentences the motivation.

Trying to build a query dynamically and log it

**Description**
Seems like there was a mass change from `st` to `statement` during rethinkdb 2.1->2.4 but that specifically property was not converted right, thus, left the changed line defunc. 

This PR changes it back to `st` until maintainer finishes the refactor


**Code examples**

```python
from rethinkdb import r
filtering_query_b = (r.row["something"] == "someone") & (r.row["else"] == "else")
print(str(filtering_query_b))
```

will yield an error of

```
Unable to serialize object: 'And' object has no attribute 'statement_infix'
```


**Checklist**
- [x] I have read and agreed to the [RethinkDB Contributor License Agreement](http://rethinkdb.com/community/cla/)

