### PR TITLE
Remove loop params that break in Python 3.10

### DIFF
--- a/rethinkdb/asyncio_net/net_asyncio.py
+++ b/rethinkdb/asyncio_net/net_asyncio.py
@@ -75,7 +75,7 @@ def reusable_waiter(loop, timeout):
             new_timeout = max(deadline - loop.time(), 0)
         else:
             new_timeout = None
-        return (yield from asyncio.wait_for(future, new_timeout, loop=loop))
+        return (yield from asyncio.wait_for(future, new_timeout))
 
     return wait
 
@@ -202,7 +202,6 @@ class ConnectionInstance(object):
             self._streamreader, self._streamwriter = yield from asyncio.open_connection(
                 self._parent.host,
                 self._parent.port,
-                loop=self._io_loop,
                 ssl=ssl_context,
             )
             self._streamwriter.get_extra_info("socket").setsockopt(
@@ -233,7 +232,6 @@ class ConnectionInstance(object):
                     response = yield from asyncio.wait_for(
                         _read_until(self._streamreader, b"\0"),
                         timeout,
-                        loop=self._io_loop,
                     )
                     response = response[:-1]
         except ReqlAuthError:

--- a/rethinkdb/asyncio_net/net_asyncio.py
+++ b/rethinkdb/asyncio_net/net_asyncio.py
@@ -227,7 +227,7 @@ class ConnectionInstance(object):
                         break
                     # This may happen in the `V1_0` protocol where we send two requests as
                     # an optimization, then need to read each separately
-                    if request is not "":
+                    if request != "":
                         self._streamwriter.write(request)
 
                     response = yield from asyncio.wait_for(


### PR DESCRIPTION
Addresses #264.  This problem could be reproduced with the README.

The loop parameter as documented in 3.9 is optional.  In 3.10 it is removed.

https://docs.python.org/3.9/library/asyncio-stream.html#asyncio.open_connection

**Checklist**
- [x] I have read and agreed to the [RethinkDB Contributor License Agreement](http://rethinkdb.com/community/cla/)
