### PR TITLE
Update LooseVersion dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 async-generator==1.10; python_version>="3.6"
 codacy-coverage==1.3.11
+looseversion==1.3.0
 mock==3.0.5
 pytest-cov==2.10.1
 pytest-tornasync==0.6.0.post2; python_version >= '3.5'

--- a/rethinkdb/utils_common.py
+++ b/rethinkdb/utils_common.py
@@ -19,7 +19,7 @@ from __future__ import print_function
 
 import collections
 import copy
-import distutils.version
+from looseversion import LooseVersion
 import getpass
 import inspect
 import optparse
@@ -146,7 +146,7 @@ def print_progress(ratio, indent=0, read=None, write=None):
 
 
 def check_minimum_version(options, minimum_version="1.6", raise_exception=True):
-    minimum_version = distutils.version.LooseVersion(minimum_version)
+    minimum_version = LooseVersion(minimum_version)
     version_string = options.retryQuery(
         "get server version",
         query.db("rethinkdb").table("server_status")[0]["process"]["version"],
@@ -159,7 +159,7 @@ def check_minimum_version(options, minimum_version="1.6", raise_exception=True):
     if not matches:
         raise RuntimeError("invalid version string format: %s" % version_string)
 
-    if distutils.version.LooseVersion(matches.group("version")) < minimum_version:
+    if LooseVersion(matches.group("version")) < minimum_version:
         if raise_exception:
             raise RuntimeError(
                 "Incompatible version, expected >= %s got: %s"


### PR DESCRIPTION
Fixes #299 and fixes a driver bug on Python 3.12

Note that this is built on other PRs, it needs the #298 PR to be merged first.

**Checklist**
- [x] I have read and agreed to the [RethinkDB Contributor License Agreement](http://rethinkdb.com/community/cla/)
