### PR TITLE
Specify 'coverage' package version in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,6 @@
 async-generator==1.10; python_version>="3.6"
+coverage<=4.5.4; python_version<"3.5"
+coverage==5.5; python_version>="3.5"
 codacy-coverage==1.3.11
 looseversion==1.3.0
 mock==3.0.5


### PR DESCRIPTION
This specifieds the `coverage` package version so that Python 3.5 is compatible.

Internally, another package depends on version `">=4.4"`, and the latest `coverage` version exhibited some syntax incompatibility with older Pythons.

Also, this PR depends on #302.

**Checklist**
- [x] I have read and agreed to the [RethinkDB Contributor License Agreement](http://rethinkdb.com/community/cla/)
