### PR TITLE
Make _restore.py -i db.table option work

### DIFF
--- a/rethinkdb/_restore.py
+++ b/rethinkdb/_restore.py
@@ -244,7 +244,7 @@ def do_unzip(temp_dir, options):
                 )
 
             # filter out tables we are not looking for
-            table = os.path.splitext(file_name)
+            table = os.path.splitext(file_name)[0]
             if tables_to_export and not (
                 (db, table) in tables_to_export or (db, None) in tables_to_export
             ):


### PR DESCRIPTION
Fixes #307

It looks like it's been broken since 289ddb90, July 2016.

**Checklist**
- [x] I have read and agreed to the [RethinkDB Contributor License Agreement](http://rethinkdb.com/community/cla/)
