### PR TITLE
fix: do not depend on package to get the version

### DIFF
--- a/rethinkdb/version.py
+++ b/rethinkdb/version.py
@@ -15,4 +15,4 @@
 # This file incorporates work covered by the following copyright:
 # Copyright 2010-2016 RethinkDB, all rights reserved.
 
-VERSION = "2.4.0+source"
+VERSION = "2.4.11+source"

--- a/setup.py
+++ b/setup.py
@@ -21,8 +21,6 @@ import re
 
 import setuptools
 
-from rethinkdb.version import VERSION
-
 try:
     import asyncio
 
@@ -32,25 +30,21 @@ except ImportError:
 
 
 RETHINKDB_VERSION_DESCRIBE = os.environ.get("RETHINKDB_VERSION_DESCRIBE")
-VERSION_RE = r"^v(?P<version>\d+\.\d+)\.(?P<patch>\d+)?(\.(?P<post>\w+))?$"
+VERSION_RE = r"(?P<major>[0-9]+)\.(?P<minor>[0-9]+)\.(?P<patch>[0-9]+)(?P<pre_release>:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?P<meta>:\+[0-9A-Za-z-]+)?"
+
+with open("rethinkdb/version.py", "r") as f:
+    version_parts = re.search(VERSION_RE, f.read()).groups()
+    VERSION = ".".join(filter(lambda x: x is not None, version_parts))
+
 
 if RETHINKDB_VERSION_DESCRIBE:
-    MATCH = re.match(VERSION_RE, RETHINKDB_VERSION_DESCRIBE)
+    version_parts = re.match(VERSION_RE, RETHINKDB_VERSION_DESCRIBE)
 
-    if MATCH:
-        VERSION = MATCH.group("version")
-
-        if MATCH.group("patch"):
-            VERSION += "." + MATCH.group("patch")
-
-        if MATCH.group("post"):
-            VERSION += "." + MATCH.group("post")
-
-        with open("rethinkdb/version.py", "w") as f:
-            f.write('VERSION = {0}'.format(repr(VERSION)))
-    else:
+    if not version_parts:
         raise RuntimeError("{!r} does not match version format {!r}".format(
             RETHINKDB_VERSION_DESCRIBE, VERSION_RE))
+
+    VERSION = ".".join(filter(lambda x: x is not None, version_parts.groups()))
 
 
 setuptools.setup(


### PR DESCRIPTION
**Reason for the change**
Fixes https://github.com/rethinkdb/rethinkdb-python/issues/309 and unblocks https://github.com/rethinkdb/rethinkdb-python/issues/311

**Description**
The way we read the package version is depending on the package itself, hence pip cannot install the packages that are listed in `install_requires`. The reason we didn't encounter this issue yet is that `six` is required by many packages, hence it was already installed for target systems.

**Code examples**
To check the fix working:

1. Clone the repo
2. DO NOT switch to this branch
3. Run `pip install .`
4. The installation fails
5. Checkout this branch
6. Run `pip install .`
7. The installation works

**Checklist**
- [x] I have read and agreed to the [RethinkDB Contributor License Agreement](http://rethinkdb.com/community/cla/)

**References**
N/A

cc: @srh 